### PR TITLE
Allowing '-' character in bound type names

### DIFF
--- a/runtime/llvmir.scm
+++ b/runtime/llvmir.scm
@@ -80,7 +80,7 @@
 
 (define impc:ir:regex-tc-or-a (string-append "((\\[|\\<)(?<struct>[^<>\\[\\]]|(\\[|\\<)\\g<struct>*(\\]|\\>)\\**)*(\\]|\\>)\\**)"
 					     "|(\\|[0-9](?<array>[^\\|]|\\|[0-9]\\g<array>*\\|\\**)*\\|\\**)"
-					     "|(?:([%0-9a-zA-Z_]\\**)+)"))
+					     "|(?:([%0-9a-zA-Z_-]\\**)+)"))
 
 
 (define impc:ir:get-type-from-pretty-array

--- a/runtime/llvmir3.scm
+++ b/runtime/llvmir3.scm
@@ -116,7 +116,7 @@
 
 (define impc:ir:regex-tc-or-a (string-append "((\\[|\\<)(?<struct>[^<>\\[\\]]|(\\[|\\<)\\g<struct>*(\\]|\\>)\\**)*(\\]|\\>)\\**)"
 					     "|(\\|[0-9](?<array>[^\\|]|\\|[0-9]\\g<array>*\\|\\**)*\\|\\**)"
-					     "|(?:([%0-9a-zA-Z_]\\**)+)"))
+					     "|(?:([%0-9a-zA-Z_-]\\**)+)"))
 
 
 (define impc:ir:get-type-from-pretty-array


### PR DESCRIPTION
Hi Andrew

Was playing with bind-type the other day, noticed that this, which felt like scheme, would fail hard:

(bind-type foo-bar <i32>)
(bind-type bar-foo <foo-bar,i32>)

I've fixed it (a quick futz to the regexps), and the tests appear to run clean

simon
