### PR TITLE
Fixed vim plugin to get rid of 'unexpected EOF while parsing' error

### DIFF
--- a/extras/extempore.vim
+++ b/extras/extempore.vim
@@ -30,11 +30,11 @@
 "   - clean up code a bit
 
 " Define all of the Extempore commands
-command! -nargs=* ExtemporeOpenConnection :python open()<CR>
-command! -nargs=* ExtemporeCloseConnection :python close()<CR>
-command! -nargs=* ExtemporeSendEnclosingBlock :python send_enclosing_block()<CR>
-command! -nargs=* ExtemporeSendEntireFile :python send_entire_file()<CR>
-command! -nargs=* ExtemporeSendSelection :python send_selection()<CR>
+command! -nargs=* ExtemporeOpenConnection :python open()
+command! -nargs=* ExtemporeCloseConnection :python close()
+command! -nargs=* ExtemporeSendEnclosingBlock :python send_enclosing_block()
+command! -nargs=* ExtemporeSendEntireFile :python send_entire_file()
+command! -nargs=* ExtemporeSendSelection :python send_selection()
 
 " These are the mappings I found to be convenient, which
 " didn't interfere with my own personal setup. Feel free to change them.


### PR DESCRIPTION
When trying to use any of the commands that the plugin provides (open connection, close connection, etc), I would get an 'unexpected EOF while parsing' error. Making these changes causes it to work properly. I don't know much about vim or vim+python so I'm not sure if this is the best fix. I'm also curious as to why no one else has complained about it not working.
