### PR TITLE
Fixed OSX frameworks' names

### DIFF
--- a/config/darwin.make
+++ b/config/darwin.make
@@ -1,8 +1,8 @@
 OSX_FRAMEWORKS := \
-	-framework cocoa \
-	-framework coreaudio \
-	-framework glut \
-	-framework opengl \
+	-framework Cocoa \
+	-framework CoreAudio \
+	-framework GLUT \
+	-framework OpenGL \
 
 PLATFORM_LIBS := -lpcre
 


### PR DESCRIPTION
Fixed OSX frameworks' names in order to make it possible to build extempore on case-sensitive filesystems.
