### PR TITLE
updated variable names and values to be consistent with standard MIDI specification

### DIFF
--- a/examples/external/midi.xtm
+++ b/examples/external/midi.xtm
@@ -38,7 +38,6 @@
 
 (define *midi-in* (midi_new_indevice))
 (define *midi-out* (midi_new_outdevice))
-(define *midi-cc 11) ;; midi control change
 
 ;; query for valid midi output devices
 (midi_query_outports *midi-out*)
@@ -49,15 +48,16 @@
 ;; use control change messages to change
 ;; the pitch of an oscillator
 (bind-func midi_cc_receive
-  (let ((type:i8 0) (chan:i8 0) (a:i8 0) (b:float 0.)
+  (let ((type:i8 0) (chan:i8 0) (a:i8 0) (b:i8 0)
         (left:i8 1) (right:i8 2))
     (lambda (time:double len:i64 msg:i8*)
       (set! type (>> (pref msg 0) 4))
       (set! chan (& (pref msg 0) 15))
       (set! a (pref msg 1))
-      (set! b (i8tof (pref msg 2)))
-      (if (= a left) (dsp.freql (+ 110. (pow b 1.25))))
-      (if (= a right) (dsp.freqr (+ 110. (pow b 1.25))))
+      (set! b (pref msg 2))
+      (println type chan a b)
+      (if (= a left) (dsp.freql (+ 110. (pow (i8tof b) 1.25))))
+      (if (= a right) (dsp.freqr (+ 110. (pow (i8tof b) 1.25))))
       void)))
 
 ;; register an *midi-in* to "midi_callback"

--- a/libs/external/rtmidi-scm.xtm
+++ b/libs/external/rtmidi-scm.xtm
@@ -1,11 +1,11 @@
 (define *midi-note-off* 8)              ;; key, velocity
 (define *midi-note-on* 9)               ;; key, velocity
-(define *midi-aftertouch* 10)            ;; key, touch
-(define *midi-continuous-controller* 11) ;; controller, value
-(define *midi-cc* 11) ;; controller, value
-(define *midi-patch-change* 12)           ;;
-(define *midi-channel-pressure* 13)      ;;
-(define *midi-pitch-bend* 14)            ;; lsb (7 bits), msb (7 bits)
+(define *midi-aftertouch* 10)           ;; key, touch
+(define *midi-control-change* 11)       ;; controller, value
+(define *midi-cc* 11)                   ;; controller, value
+(define *midi-program-change* 12)       ;; value, ignored
+(define *midi-channel-pressure* 13)     ;; value, ignored
+(define *midi-pitch-bend* 14)           ;; lsb (7 bits), msb (7 bits)
 
 (define *midi-in-device* #f)
 (define *midi-out-device* #f)

--- a/libs/external/rtmidi.xtm
+++ b/libs/external/rtmidi.xtm
@@ -62,8 +62,9 @@
 (bind-val MIDI_NOTE_OFF i8 *midi-note-off*)
 (bind-val MIDI_NOTE_ON i8 *midi-note-on*)
 (bind-val MIDI_AFTERTOUCH i8 *midi-aftertouch*)
-(bind-val MIDI_CONTINUOUS_CONTROLLER i8 *midi-continuous-controller*)
-(bind-val MIDI_PATCH_CHANGE i8 *midi-patch-change*)
+(bind-val MIDI_CONTROL_CHANGE i8 *midi-control-change*)
+(bind-val MIDI_CC i8 *midi-control-change*)
+(bind-val MIDI_PROGRAM_CHANGE i8 *midi-program-change*)
 (bind-val MIDI_CHANNEL_PRESSURE i8 *midi-channel-pressure*)
 (bind-val MIDI_PITCH_BEND i8 *midi-pitch-bend*)
 


### PR DESCRIPTION
I also note that the rtmidi-scm.txm file seems reduncdent. It is in the master branch but not in the branch donwloaded when using Brew Install. I've made changes to it to keep consistency in any case.
