### PR TITLE
minimised -1 output from pc:random

### DIFF
--- a/libs/core/pc_ivl.xtm
+++ b/libs/core/pc_ivl.xtm
@@ -693,4 +693,5 @@
               (ivl:melody-by-ivl (+ starting-pitch (car ivls)) (cdr ivls) 
                                  (cons (+ starting-pitch (car ivls)) (car args)))))))
 
+(println "Loaded pc-ivl.xtm library\n")
                  


### PR DESCRIPTION
Added the pc:exhaustive function to do a brute force search for a
solution before returning -1. This is called from pc:random after
several random values have still failed to find a solution.
