### PR TITLE
Fix make-tags.sh for Linux

### DIFF
--- a/extras/make-tags.sh
+++ b/extras/make-tags.sh
@@ -2,10 +2,11 @@
 
 [ -f TAGS ] && rm TAGS
 
-case $(uname) in
-  'Linux')  FIND_CMD='find . -regextype posix-extended';;
-  'Darwin') FIND_CMD='find -E .';;
-esac
+if find -version 2>/dev/null | grep GNU > /dev/null; then
+  FIND_CMD='find . -regextype posix-extended'
+else
+  FIND_CMD='find -E .'
+fi
 
 # make extempore/xtlang tags
 $FIND_CMD -regex '.*/.*\.(cpp|h)$' -print | etags -


### PR DESCRIPTION
Due differences between BSD and GNU find this was broken on linux. Tested on Archlinux, will hopefully work with other distros.
