### PR TITLE
UNIV::SAMPLERATE matches device SampleRate. Fixes PA with Jack backend

### DIFF
--- a/src/AudioDevice.cpp
+++ b/src/AudioDevice.cpp
@@ -715,9 +715,12 @@ namespace extemp {
       paout.hostApiSpecificStreamInfo = NULL;
       PaStreamParameters* paoutptr = &paout;
       if(UNIV::CHANNELS<1) paoutptr=NULL;
+      UNIV::SAMPLERATE = deviceInfo->defaultSampleRate;
 
       err = Pa_OpenStream(&stream, painptr, paoutptr, UNIV::SAMPLERATE, UNIV::FRAMES, paNoFlag, audioCallback, (void*)TaskScheduler::I());
     }else{
+      deviceInfo = Pa_GetDeviceInfo( outputDevice );
+      UNIV::SAMPLERATE = deviceInfo->defaultSampleRate;
       err = Pa_OpenDefaultStream(&stream, 0, UNIV::CHANNELS, paFloat32, UNIV::SAMPLERATE, UNIV::FRAMES, audioCallback, (void*)TaskScheduler::I());
     }
     // std::cout << "Input Device: " << inputDevice << std::endl;


### PR DESCRIPTION
Fixes https://github.com/digego/extempore/issues/160

Tested with portaudio over pulse, as well as JACK with samplerate at 48000 and 44100.
Not entirely sure is there are unintended side-effects for this, but presumably matching
the sample rate of the target even if mismatches didn't crash extempore is reasonable.
