### PR TITLE
extemopre.el fixes

### DIFF
--- a/extras/extempore.el
+++ b/extras/extempore.el
@@ -1084,7 +1084,7 @@ If there is a process already running in `*extempore*', switch to that buffer.
            proc
            (concat (buffer-substring-no-properties start end) "\r\n")))
         (sleep-for extempore-blink-duration))
-    (error "Buffer %s is not connected to an Extempore process.  You can connect with `M-x extempore-connect' (C-x C-j)" (buffer-name))))
+    (error "Buffer %s is not connected to an Extempore process.  You can connect with `M-x extempore-connect' (C-c C-j)" (buffer-name))))
 
 (defun extempore-send-definition ()
   "Send the current definition to the inferior Extempore process."


### PR DESCRIPTION
`extempore-repl` wasn't working for me, so I made a few improvements:
- If the user doesn't manually specify `--runtime` the defun adds it in relative to `user-extempore-directory`.
- Everything still works if user-extempore-directory includes "~/" or if the user forgot the trailing
  slash.
- `extempore-repl` now polls the comint buffer every second and as soon as its ready it gets on with it.
- If either/both the process buffer or the REPL buffer are missing, they'll get spun up.
- If the user asks for `extempore-repl` and the repl is already running, switch to it just the same.
