### PR TITLE
fix string ouptup ports, see tinyscheme r37

### DIFF
--- a/include/OPDefines.h
+++ b/include/OPDefines.h
@@ -164,8 +164,9 @@ _OP_DEF(opexe_4, "open-output-file",               1,  1,       TST_STRING,     
 _OP_DEF(opexe_4, "open-input-output-file",         1,  1,       TST_STRING,                      OP_OPEN_INOUTFILE   )
 #if USE_STRING_PORTS
 _OP_DEF(opexe_4, "open-input-string",              1,  1,       TST_STRING,                      OP_OPEN_INSTRING    )
-_OP_DEF(opexe_4, "open-output-string",             1,  1,       TST_STRING,                      OP_OPEN_OUTSTRING   )
 _OP_DEF(opexe_4, "open-input-output-string",       1,  1,       TST_STRING,                      OP_OPEN_INOUTSTRING )
+_OP_DEF(opexe_4, "open-output-string",             0,  1,       TST_STRING,                      OP_OPEN_OUTSTRING   )
+_OP_DEF(opexe_4, "get-output-string",              1,  1,       TST_OUTPORT,                     OP_GET_OUTSTRING    )
 #endif
 _OP_DEF(opexe_4, "close-input-port",               1,  1,       TST_INPORT,                      OP_CLOSE_INPORT     )
 _OP_DEF(opexe_4, "close-output-port",              1,  1,       TST_OUTPORT,                     OP_CLOSE_OUTPORT    )

--- a/include/SchemePrivate.h
+++ b/include/SchemePrivate.h
@@ -75,7 +75,8 @@ class EXTThread;
 enum scheme_port_kind { 
     port_free=0, 
     port_file=1, 
-    port_string=2, 
+    port_string=2,
+    port_srfi6=4,
     port_input=16, 
     port_output=32 
 };


### PR DESCRIPTION
While trying to parse json files, I noticed that the current implementation of string output ports is kind of nonsense:
- `open-output-string` takes an unneccerary argument
- `get-output-string` is missing

This has been fixed in TinyScheme in 2007, so I backported the changes. Since there are probably other interesting improvements in TinyScheme, would it be possible/desirable to rebase extempore on a more recent version of TinyScheme in a way that allows to keep it up to date? Is there a way to track what has been changed so far?