### PR TITLE
extempore.el: run first, blink later in extempore-send-region

### DIFF
--- a/extras/extempore.el
+++ b/extras/extempore.el
@@ -1078,11 +1078,11 @@ If there is a process already running in `*extempore*', switch to that buffer.
   (interactive "r")
   (if extempore-connection-list
       (let ((transient-mark-mode nil))
-        (extempore-blink-region extempore-blink-overlay start end)
         (dolist (proc extempore-connection-list)
           (process-send-string
            proc
            (concat (buffer-substring-no-properties start end) "\r\n")))
+        (extempore-blink-region extempore-blink-overlay start end)
         (sleep-for extempore-blink-duration))
     (error "Buffer %s is not connected to an Extempore process.  You can connect with `M-x extempore-connect' (C-c C-j)" (buffer-name))))
 


### PR DESCRIPTION
emacs evaluation feels sluggish because the code isn't sent to extempore until emacs finishes blinking things. It looks the same as far as the user is concerned, only extempore feels more responsive. easy pickings.

Setting `extempore-blink-duration` to a smaller (or 0) value also helps, if you're doing C-x C-e trills.
