### PR TITLE
Convenience configure script for building extempore with cmake

### DIFF
--- a/configure
+++ b/configure
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+TMP_EXT_SOURCE_DIR=`pwd`
+CMAKE_BUILD_DIR=cmake-build
+
+mkdir -p $CMAKE_BUILD_DIR && cd $CMAKE_BUILD_DIR
+cmake -DEXT_SHARE_DIR=$TMP_EXT_SOURCE_DIR ..
+
+# generate pseudo makefile that point to cmake makefile
+printf 'all: ;$(MAKE) -C %s all 
+install: ;$(MAKE) -C %s install
+clean: ;$(MAKE) -C %s clean
+' "$CMAKE_BUILD_DIR" "$CMAKE_BUILD_DIR" "$CMAKE_BUILD_DIR" > $TMP_EXT_SOURCE_DIR/Makefile


### PR DESCRIPTION
Sets up cmake files, generates a pseudo makefile in the base directory.

Basically allows the user to do:

>> ./configure && make && make install

from the extempore directory