### PR TITLE
Make EXTLLVM use EXTThread

### DIFF
--- a/include/EXTThread.h
+++ b/include/EXTThread.h
@@ -53,7 +53,7 @@ namespace extemp
 #ifdef _WIN32
 	EXTThread(std::thread&& _bthread);
 #else
-	EXTThread(std::thread&& _pthread);
+	EXTThread(pthread_t _pthread);
 #endif
 	~EXTThread();
 

--- a/include/EXTThread.h
+++ b/include/EXTThread.h
@@ -36,7 +36,7 @@
 #ifndef EXT_THREAD
 #define EXT_THREAD
 
-#ifdef EXT_BOOST
+#ifdef _WIN32
 #include <thread>
 #include <functional>
 #else
@@ -50,16 +50,23 @@ namespace extemp
     {
     public:
 	EXTThread();
+#ifdef _WIN32
+	EXTThread(std::thread&& _bthread);
+#else
+	EXTThread(std::thread&& _pthread);
+#endif
 	~EXTThread();
 
 	int create(void *(*start_routine)(void *), void *arg);
+	int kill();
 	int detach();
 	int join();
 	bool isRunning();
 	bool isCurrentThread();
 	int setPriority(int, bool);
 	int getPriority(); //doesn't say if it's realtime or not
-#ifdef EXT_BOOST
+	bool isEqualTo(EXTThread* other_thread);
+#ifdef _WIN32
 	std::thread& getBthread();
 #else
 	pthread_t getPthread();
@@ -70,7 +77,7 @@ namespace extemp
 	bool detached;
 	bool joined;
 	bool cancelled;			
-#ifdef EXT_BOOST
+#ifdef _WIN32
 	std::thread bthread;
 #else
 	pthread_t pthread;

--- a/src/EXTThread.cpp
+++ b/src/EXTThread.cpp
@@ -61,9 +61,9 @@ namespace extemp
 	{
 	}
 #else
-	EXTThread::EXTThread(std::thread&& _pthread) : initialised(false), detached(false), joined(false), bthread{ std::move(_pthread) }
-	{
-	}
+    EXTThread::EXTThread(pthread_t _pthread) : initialised(false), detached(false), joined(false), pthread{ _pthread }
+    {
+    }
 #endif
 
     EXTThread::~EXTThread()

--- a/src/EXTThread.cpp
+++ b/src/EXTThread.cpp
@@ -56,6 +56,16 @@ namespace extemp
     {       
     }
 
+#ifdef _WIN32
+	EXTThread::EXTThread(std::thread&& _bthread) : initialised(false), detached(false), joined(false), bthread{ std::move(_bthread) }
+	{
+	}
+#else
+	EXTThread::EXTThread(std::thread&& _pthread) : initialised(false), detached(false), joined(false), bthread{ std::move(_pthread) }
+	{
+	}
+#endif
+
     EXTThread::~EXTThread()
     {		
 #ifdef _EXTTHREAD_DEBUG_
@@ -72,7 +82,7 @@ namespace extemp
 
 	if (! initialised)
 	{
-#ifdef EXT_BOOST
+#ifdef _WIN32
     // std::function<void*(void*)> fn = static_cast<std::function<void*(void*)> >(start_routine);
     std::function<void*()> fn = [start_routine,arg]()->void* { return start_routine(arg); };
     bthread = std::thread(fn);
@@ -91,7 +101,16 @@ namespace extemp
 #endif
 
 	return result;
-    }    
+    }
+
+	int EXTThread::kill()
+	{
+#ifdef _WIN32
+		return 0;
+#else
+		return pthread_cancel(pthread);
+#endif
+	}
 
 
     int EXTThread::detach()
@@ -100,7 +119,7 @@ namespace extemp
 
 	if (initialised)
 	{
-#ifdef EXT_BOOST
+#ifdef _WIN32
 	    bthread.detach();
 	    result = 0;
 #else
@@ -125,7 +144,7 @@ namespace extemp
 
 	if (initialised)
 	{
-#ifdef EXT_BOOST
+#ifdef _WIN32
 	    bthread.join();
             result = 0;
 #else
@@ -146,7 +165,7 @@ namespace extemp
 
   int EXTThread::setPriority(int priority, bool realtime)
   {
-#ifdef EXT_BOOST
+#ifdef _WIN32
     auto thread = bthread.native_handle();
 #else
 	pthread_t thread = pthread;
@@ -209,7 +228,7 @@ namespace extemp
   
     bool EXTThread::isRunning() 
     { 
-#ifdef EXT_BOOST
+#ifdef _WIN32
       return initialised;
 #else
 	return 0 != pthread; 
@@ -218,14 +237,23 @@ namespace extemp
 	
     bool EXTThread::isCurrentThread()
     {
-#ifdef EXT_BOOST
+#ifdef _WIN32
       return (bthread.get_id() == std::this_thread::get_id());
 #else
 	return pthread_equal(pthread_self(), pthread);
 #endif
     }
-	
-#ifdef EXT_BOOST
+
+	bool EXTThread::isEqualTo(EXTThread* other_thread)
+	{
+#ifdef _WIN32
+		return bthread.get_id() == other_thread->getBthread().get_id();		
+#else
+		return pthread_equal(pthread, other_thread->getPthread());
+#endif  
+	}
+
+#ifdef _WIN32
   std::thread& EXTThread::getBthread()
     {
 	return bthread;


### PR DESCRIPTION
This improves EXTThread to work under Windows and Unix in a consistent and abstracted fashion. It also makes EXTLLVM use EXTThread to improve seperation of concerns.