### PR TITLE
add thread-first and thread-last macros

### DIFF
--- a/libs/core/thread.xtm
+++ b/libs/core/thread.xtm
@@ -1,0 +1,35 @@
+
+;; -> 
+;; Use of `->` (the "thread-first" macro) can help make code
+;; more readable by removing nesting.
+;; Threads the first expr passed to the macro into the first position in the second sexp.
+;; Recursively continues to thread the resultant sexp into any further sexp arguments.
+
+(define-macro (-> value . args)
+  (if (null? args)
+      value
+      (let loop ((thread-items args)
+                 (transformed value))
+        (if (null? thread-items)
+            transformed
+            (loop 
+             (cdr thread-items)
+             (insert-at-index 1 (car thread-items) transformed))))))
+
+
+;; ->>
+;; Use of `->>` (the "thread-last" macro) can help make code
+;; more readable by removing nesting.
+;; Threads the first expr passed to the macro into the last position in the second sexp.
+;; Recursively continues to thread the resultant sexp into any further sexp arguments.
+
+(define-macro (->> value . args)
+  (if (null? args)
+      value
+      (let loop ((thread-items args)
+                 (transformed value))
+        (if (null? thread-items)
+            transformed
+            (loop 
+             (cdr thread-items)
+             (insert-at-index (length (car thread-items)) (car thread-items) transformed))))))

--- a/tests/core/thread.xtm
+++ b/tests/core/thread.xtm
@@ -1,0 +1,38 @@
+
+(sys:load "libs/core/thread.xtm")
+(sys:load "libs/core/adt.xtm")
+
+(xtmtest '(bind-func test_thread_first1
+            (lambda ()
+              (-> "this string is 33 characters long"
+                  (strlen)
+                  )))
+         (test_thread_first1) 33)
+
+(xtmtest '(bind-func test_thread_first2
+            (lambda ()
+              (-> 1
+                  (+ 2)
+                  (* 2)
+                  (modulo 2)
+                  )))
+         (test_thread_first2) 0)
+
+(xtmtest '(bind-func test_thread_last1
+            (lambda ()
+              (->> (list 1 2 3)
+                   (map (lambda (x) (+ x 1)))
+                   (filter (lambda (x) (= (modulo x 2) 0)))
+                   (car)
+                   )))
+         (test_thread_last1) 2)
+
+(xtmtest '(bind-func test_thread_last2
+            (lambda ()
+              (->> 1
+                  (+ 2)
+                  (* 2)
+                  (modulo 2)
+                  )))
+         (test_thread_last2) 2)
+


### PR DESCRIPTION
The thread first and thread last macros (depicted -> and ->> respectively) are a pretty nice abstraction for dealing with nested operations. I have only used them within Clojure, so possibly there is variance in behaviour in other languages that have them, but these behave like the Clojure versions (I hope!). 

The tests should give an idea of expected behaviour.

I wasn't really sure where to put them in the source tree given #199, but I figured a pull request in the hand is worth two in the bush. 