### PR TITLE
Std xtm rename

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,35 +545,35 @@ else(WIN32)
 
   # core
   add_custom_target(aot)
-  aotcompile_lib(libs/core/std.xtm aot 17099) # no lib dependency for std.xtm
-  aotcompile_lib(libs/core/math.xtm aot 17097 std)
-  aotcompile_lib(libs/core/audio_dsp.xtm aot 17095 std math)
-  aotcompile_lib(libs/core/instruments.xtm aot 17093 std math audio_dsp)
+  aotcompile_lib(libs/base/base.xtm aot 17099) # no lib dependency base.xtm
+  aotcompile_lib(libs/core/math.xtm aot 17097 base)
+  aotcompile_lib(libs/core/audio_dsp.xtm aot 17095 base math)
+  aotcompile_lib(libs/core/instruments.xtm aot 17093 base math audio_dsp)
 
   # extended
   add_custom_target(aot_extended)
-  aotcompile_lib(libs/external/fft.xtm aot_extended 17091 std math)
-  aotcompile_lib(libs/external/sndfile.xtm aot_extended 17089 std)
-  aotcompile_lib(libs/core/audiobuffer.xtm aot_extended 17087 std audio_dsp sndfile)
-  aotcompile_lib(libs/external/audio_dsp_ext.xtm aot_extended 17085 std fft sndfile)
-  aotcompile_lib(libs/external/instruments_ext.xtm aot_extended 17083 std sndfile instruments)
-  aotcompile_lib(libs/external/portmidi.xtm aot_extended 17081 std)
-  aotcompile_lib(libs/external/stb_image.xtm aot_extended 17077 std)
-  aotcompile_lib(libs/external/glfw3.xtm aot_extended 17075 std)
+  aotcompile_lib(libs/external/fft.xtm aot_extended 17091 base math)
+  aotcompile_lib(libs/external/sndfile.xtm aot_extended 17089 base)
+  aotcompile_lib(libs/core/audiobuffer.xtm aot_extended 17087 base audio_dsp sndfile)
+  aotcompile_lib(libs/external/audio_dsp_ext.xtm aot_extended 17085 base fft sndfile)
+  aotcompile_lib(libs/external/instruments_ext.xtm aot_extended 17083 base sndfile instruments)
+  aotcompile_lib(libs/external/portmidi.xtm aot_extended 17081 base)
+  aotcompile_lib(libs/external/stb_image.xtm aot_extended 17077 base)
+  aotcompile_lib(libs/external/glfw3.xtm aot_extended 17075 base)
   if(WIN32)
     set(GL_BIND_METHOD getprocaddress)
   else()
     set(GL_BIND_METHOD directbind)
   endif()
-  aotcompile_lib(libs/external/gl/glcore-${GL_BIND_METHOD}.xtm aot_extended 17073 std)
-  aotcompile_lib(libs/external/gl/gl-objects.xtm aot_extended 17071 std glcore-${GL_BIND_METHOD} stb_image)
-  aotcompile_lib(libs/external/nanovg.xtm aot_extended 17069 std glcore-${GL_BIND_METHOD})
-  aotcompile_lib(libs/external/gl/glcompat-${GL_BIND_METHOD}.xtm aot_extended 17067 std)
-  aotcompile_lib(libs/external/graphics-pipeline.xtm aot_extended 17065 std glcompat-${GL_BIND_METHOD})
+  aotcompile_lib(libs/external/gl/glcore-${GL_BIND_METHOD}.xtm aot_extended 17073 base)
+  aotcompile_lib(libs/external/gl/gl-objects.xtm aot_extended 17071 base glcore-${GL_BIND_METHOD} stb_image)
+  aotcompile_lib(libs/external/nanovg.xtm aot_extended 17069 base glcore-${GL_BIND_METHOD})
+  aotcompile_lib(libs/external/gl/glcompat-${GL_BIND_METHOD}.xtm aot_extended 17067 base)
+  aotcompile_lib(libs/external/graphics-pipeline.xtm aot_extended 17065 base glcompat-${GL_BIND_METHOD})
   if(NOT WIN32)
     # these ones don't currently work on Windows
-    aotcompile_lib(libs/external/glib.xtm aot_extended 17079 std)
-    aotcompile_lib(libs/external/assimp.xtm aot_extended 17063 std stb_image graphics-pipeline)
+    aotcompile_lib(libs/external/glib.xtm aot_extended 17079 base)
+    aotcompile_lib(libs/external/assimp.xtm aot_extended 17063 base stb_image graphics-pipeline)
   endif()
 
 endif(WIN32)
@@ -594,7 +594,7 @@ add_custom_target(xtmdoc
   COMMAND ${CMAKE_INSTALL_PREFIX}/bin/extempore
            --runtime ${EXT_SHARE_DIR}
            --port 17095
-           --eval "(begin (sys:load \"libs/core/audio_dsp.xtm\") (sys:load \"libs/core/instruments.xtm\") (sys:load \"libs/core/math.xtm\") (sys:load \"libs/core/std.xtm\") (sys:load \"libs/external/fft.xtm\") (sys:load \"libs/external/gl.xtm\") (sys:load \"libs/external/glfw3.xtm\") (sys:load \"libs/external/instruments_ext.xtm\") (sys:load \"libs/external/nanovg.xtm\") (sys:load \"libs/external/sndfile.xtm\") (sys:load \"libs/external/stb_image.xtm\") (xtmdoc-export-caches-to-json \"/tmp/xtmdoc.json\" #f) (quit 0))"
+           --eval "(begin (sys:load \"libs/core/audio_dsp.xtm\") (sys:load \"libs/core/instruments.xtm\") (sys:load \"libs/core/math.xtm\") (sys:load \"libs/base/base.xtm\") (sys:load \"libs/external/fft.xtm\") (sys:load \"libs/external/gl.xtm\") (sys:load \"libs/external/glfw3.xtm\") (sys:load \"libs/external/instruments_ext.xtm\") (sys:load \"libs/external/nanovg.xtm\") (sys:load \"libs/external/sndfile.xtm\") (sys:load \"libs/external/stb_image.xtm\") (xtmdoc-export-caches-to-json \"/tmp/xtmdoc.json\" #f) (quit 0))"
   COMMENT "Generating xtmdoc output in /tmp/xtmdoc.json"
   VERBATIM)
 

--- a/compile-stdlib.sh
+++ b/compile-stdlib.sh
@@ -11,7 +11,7 @@ esac
 # to override this list, call this script with:
 # AOT_LIBS="libs/core/foo.xtm libs/external/bar.xtm" ./compile-stdlib.sh
 : ${AOT_LIBS:="\
-libs/core/std.xtm \
+libs/base/base.xtm \
 libs/core/math.xtm \
 libs/core/audio_dsp.xtm \
 libs/core/instruments.xtm \

--- a/extras/cmake/aot.cmake.in
+++ b/extras/cmake/aot.cmake.in
@@ -6,7 +6,7 @@ if(UNIX)
 
   set(AOT_LIBS
     # core
-    "libs/core/std.xtm"
+    "libs/base/base.xtm"
     "libs/core/math.xtm"
     "libs/core/audio_dsp.xtm"
     "libs/core/instruments.xtm"
@@ -27,7 +27,7 @@ elseif(WIN32)
 
   set(AOT_LIBS
     # core
-    "libs/core/std.xtm"
+    "libs/base/base.xtm"
     "libs/core/math.xtm"
     "libs/core/audio_dsp.xtm"
     "libs/core/instruments.xtm"

--- a/extras/cmake/aot_extended.cmake.in
+++ b/extras/cmake/aot_extended.cmake.in
@@ -6,7 +6,7 @@ if(UNIX)
 
   set(AOT_LIBS
     # core
-    "libs/core/std.xtm"
+    "libs/base/base.xtm"
     "libs/core/math.xtm"
     "libs/core/audio_dsp.xtm"
     "libs/core/instruments.xtm"
@@ -44,7 +44,7 @@ elseif(WIN32)
 
   set(AOT_LIBS
     # core
-    "libs/core/std.xtm"
+    "libs/base/base.xtm"
     "libs/core/math.xtm"
     "libs/core/audio_dsp.xtm"
     "libs/core/instruments.xtm"

--- a/extras/generate-xtmdoc.sh
+++ b/extras/generate-xtmdoc.sh
@@ -10,7 +10,7 @@ extempore --eval "(begin
   (sys:load \"libs/core/audio_dsp.xtm\")
   (sys:load \"libs/core/instruments.xtm\")
   (sys:load \"libs/core/math.xtm\")
-  (sys:load \"libs/core/std.xtm\")
+  (sys:load \"libs/base/base.xtm\")
   (sys:load \"libs/external/fft.xtm\")
   (sys:load \"libs/external/gl.xtm\")
   (sys:load \"libs/external/glfw3.xtm\")

--- a/libs/base/base.xtm
+++ b/libs/base/base.xtm
@@ -40,8 +40,8 @@
 ;; lib-loading config
 
 (sys:load "libs/aot-cache/base.xtm" 'quiet)
-(sys:load-preload-check 'std)
-(define *xtmlib-std-loaded* #f)
+(sys:load-preload-check 'base)
+(define *xtmlib-base-loaded* #f)
 
 (impc:aot:insert-header "xtmbase")
 

--- a/libs/base/base.xtm
+++ b/libs/base/base.xtm
@@ -39,11 +39,11 @@
 
 ;; lib-loading config
 
-(sys:load "libs/aot-cache/std.xtm" 'quiet)
+(sys:load "libs/aot-cache/base.xtm" 'quiet)
 (sys:load-preload-check 'std)
 (define *xtmlib-std-loaded* #f)
 
-(impc:aot:insert-header "xtmstd")
+(impc:aot:insert-header "xtmbase")
 
 (sys:compile-init-ll)
 (impc:aot:insert-forms (sys:compile-init-ll))
@@ -944,6 +944,6 @@ Use via the polymorphic Str function
 
 (bind-poly equal Symbol_equal)
 
-(define *xtmlib-std-loaded* #t)
+(define *xtmlib-base-loaded* #t)
 
-(impc:aot:insert-footer "xtmstd")
+(impc:aot:insert-footer "xtmbase")

--- a/libs/contrib/cairo.xtm
+++ b/libs/contrib/cairo.xtm
@@ -17,8 +17,8 @@
 (sys:load-preload-check 'cairo)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 ;; set up the current dylib name and path (for AOT compilation)
 (bind-dylib libcairo

--- a/libs/contrib/drawtext.xtm
+++ b/libs/contrib/drawtext.xtm
@@ -17,8 +17,8 @@
 (sys:load-preload-check 'drawtext)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 ;; set up the current dylib name and path (for AOT compilation)
 (bind-dylib libdrawtext

--- a/libs/contrib/mpi.xtm
+++ b/libs/contrib/mpi.xtm
@@ -15,8 +15,8 @@
 (define *xtmlib-mpi-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmmpi")
 

--- a/libs/contrib/rtmidi.xtm
+++ b/libs/contrib/rtmidi.xtm
@@ -33,8 +33,8 @@
 (define *xtmlib-rtmidi-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmrtmidi")
 

--- a/libs/core/adt.xtm
+++ b/libs/core/adt.xtm
@@ -9,8 +9,8 @@
 (define *xtmlib-adt-loaded* #t)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;

--- a/libs/core/audiobuffer.xtm
+++ b/libs/core/audiobuffer.xtm
@@ -15,9 +15,9 @@
 (define *xtmlib-audiobuffer-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
+ (sys:load "libs/base/base.xtm"))
 (impc:aot:insert-forms
- (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmaudiobuffer")
 

--- a/libs/core/math.xtm
+++ b/libs/core/math.xtm
@@ -27,8 +27,8 @@
 (define *xtmlib-math-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmmath")
 

--- a/libs/external/bullet.xtm
+++ b/libs/external/bullet.xtm
@@ -13,8 +13,8 @@
 (sys:load-preload-check 'bullet)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 ;;; Code:
 

--- a/libs/external/datavis.xtm
+++ b/libs/external/datavis.xtm
@@ -15,10 +15,10 @@
 (define *xtmlib-datavis-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm")
+ (sys:load "libs/base/base.xtm")
  (sys:load "libs/external/nanovg.xtm"))
 (impc:aot:insert-forms
- (sys:load "libs/core/std.xtm" 'quiet)
+ (sys:load "libs/base/base.xtm" 'quiet)
  (sys:load "libs/external/nanovg.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmdatavis")

--- a/libs/external/fft.xtm
+++ b/libs/external/fft.xtm
@@ -35,9 +35,9 @@
 (set! *impc:compiler:message:level* 'high)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm")
+ (sys:load "libs/base/base.xtm")
  (sys:load "libs/core/math.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 (impc:aot:insert-forms (sys:load "libs/core/math.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmfft")

--- a/libs/external/ghttp.xtm
+++ b/libs/external/ghttp.xtm
@@ -18,9 +18,9 @@
 (sys:load-preload-check 'ghttp)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm")
+ (sys:load "libs/base/base.xtm")
  (sys:load "libs/external/jansson.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 (impc:aot:insert-forms (sys:load "libs/external/jansson.xtm"))
 
 ;; set up the current dylib name and path (for AOT compilation)

--- a/libs/external/gl/gl-objects.xtm
+++ b/libs/external/gl/gl-objects.xtm
@@ -17,11 +17,11 @@
 (define *xtmlib-gl-objects-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm")
+ (sys:load "libs/base/base.xtm")
  (sys:load "libs/external/gl.xtm")
  (sys:load "libs/external/stb_image.xtm"))
 (impc:aot:insert-forms
- (sys:load "libs/core/std.xtm" 'quiet)
+ (sys:load "libs/base/base.xtm" 'quiet)
  (sys:load "libs/external/gl.xtm" 'quiet)
  (sys:load "libs/external/stb_image.xtm" 'quiet))
 

--- a/libs/external/gl/gl-test.xtm
+++ b/libs/external/gl/gl-test.xtm
@@ -3,10 +3,10 @@
 (define *xtmlib-gl-test-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm")
+ (sys:load "libs/base/base.xtm")
  (sys:load "libs/external/gl/glcore-getprocaddress.xtm"))
 (impc:aot:insert-forms
- (sys:load "libs/core/std.xtm" 'quiet)
+ (sys:load "libs/base/base.xtm" 'quiet)
  (sys:load "libs/external/gl/glcore-getprocaddress.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmgl-test")

--- a/libs/external/gl/glcompat-directbind.xtm
+++ b/libs/external/gl/glcompat-directbind.xtm
@@ -22,8 +22,8 @@
 (define *xtmlib-gl-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmglcompat-directbind")
 

--- a/libs/external/gl/glcompat-getprocaddress.xtm
+++ b/libs/external/gl/glcompat-getprocaddress.xtm
@@ -29,8 +29,8 @@
 (define *xtmlib-gl-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmglcompat-getprocaddress")
 

--- a/libs/external/gl/glcore-directbind.xtm
+++ b/libs/external/gl/glcore-directbind.xtm
@@ -28,8 +28,8 @@
 (define *xtmlib-gl-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmglcore-directbind")
 

--- a/libs/external/gl/glcore-getprocaddress.xtm
+++ b/libs/external/gl/glcore-getprocaddress.xtm
@@ -27,8 +27,8 @@
 (define *xtmlib-gl-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmglcore-getprocaddress")
 

--- a/libs/external/gl/glcore-glew.xtm
+++ b/libs/external/gl/glcore-glew.xtm
@@ -25,10 +25,10 @@
 (define *xtmlib-gl-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm")
+ (sys:load "libs/base/base.xtm")
  (sys:load "libs/external/gl/glew.xtm"))
 (impc:aot:insert-forms
- (sys:load "libs/core/std.xtm" 'quiet)
+ (sys:load "libs/base/base.xtm" 'quiet)
  (sys:load "libs/external/gl/glew.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmglcore-glew")

--- a/libs/external/gl/glew.xtm
+++ b/libs/external/gl/glew.xtm
@@ -16,9 +16,9 @@
 (define *xtmlib-glew-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
+ (sys:load "libs/base/base.xtm"))
 (impc:aot:insert-forms
- (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmglew")
 

--- a/libs/external/glext.xtm
+++ b/libs/external/glext.xtm
@@ -4,8 +4,8 @@
 (define *xtmlib-glext-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmglext")
 

--- a/libs/external/glfw3.xtm
+++ b/libs/external/glfw3.xtm
@@ -15,8 +15,8 @@
 (define *xtmlib-glfw3-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmglfw3")
 

--- a/libs/external/glib.xtm
+++ b/libs/external/glib.xtm
@@ -16,8 +16,8 @@
 (define *xtmlib-glib-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmglib")
 

--- a/libs/external/gstreamer.xtm
+++ b/libs/external/gstreamer.xtm
@@ -15,8 +15,8 @@
 (sys:load-preload-check 'gstreamer)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 ;; make sure that glib is loaded
 (sys:load "libs/external/glib.xtm")

--- a/libs/external/gui.xtm
+++ b/libs/external/gui.xtm
@@ -15,10 +15,10 @@
 (define *xtmlib-gui-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm")
+ (sys:load "libs/base/base.xtm")
  (sys:load "libs/external/nanovg.xtm")
  (sys:load "libs/external/glfw3.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 (impc:aot:insert-forms (sys:load "libs/external/nanovg.xtm" 'quiet))
 (impc:aot:insert-forms (sys:load "libs/external/glfw3.xtm" 'quiet))
 

--- a/libs/external/hid.xtm
+++ b/libs/external/hid.xtm
@@ -13,8 +13,8 @@
 (sys:load-preload-check 'libhid)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 ;; lib assimp
 (define libhid

--- a/libs/external/horde3d.xtm
+++ b/libs/external/horde3d.xtm
@@ -15,8 +15,8 @@
 (sys:load-preload-check 'horde3d)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 ;; set the path to the Horde3D directory
 

--- a/libs/external/jansson.xtm
+++ b/libs/external/jansson.xtm
@@ -22,8 +22,8 @@
 (sys:load-preload-check 'jansson)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 ;; set up the current dylib name and path (for AOT compilation)
 (bind-dylib libjansson

--- a/libs/external/nanomsg.xtm
+++ b/libs/external/nanomsg.xtm
@@ -15,9 +15,9 @@
 (define *xtmlib-nanomsg-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
+ (sys:load "libs/base/base.xtm"))
 (impc:aot:insert-forms
- (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmnanomsg")
 

--- a/libs/external/nanovg.xtm
+++ b/libs/external/nanovg.xtm
@@ -23,10 +23,10 @@
 (define *xtmlib-nanovg-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm")
+ (sys:load "libs/base/base.xtm")
  (sys:load "libs/external/gl.xtm"))
 (impc:aot:insert-forms
- (sys:load "libs/core/std.xtm" 'quiet)
+ (sys:load "libs/base/base.xtm" 'quiet)
  (sys:load "libs/external/gl.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmnanovg")

--- a/libs/external/opencl.xtm
+++ b/libs/external/opencl.xtm
@@ -15,8 +15,8 @@
 (define *xtmlib-opencl-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmopencl")
 

--- a/libs/external/portaudio.xtm
+++ b/libs/external/portaudio.xtm
@@ -67,8 +67,8 @@
 (define *xtmlib-portaudio-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmportaudio")
 

--- a/libs/external/portmidi.xtm
+++ b/libs/external/portmidi.xtm
@@ -16,8 +16,8 @@
 (define *xtmlib-portmidi-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmportmidi")
 

--- a/libs/external/sndfile.xtm
+++ b/libs/external/sndfile.xtm
@@ -43,8 +43,8 @@
 (define *xtmlib-sndfile-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmsndfile")
 

--- a/libs/external/soil.xtm
+++ b/libs/external/soil.xtm
@@ -16,9 +16,9 @@
 (define *xtmlib-soil-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm")
+ (sys:load "libs/base/base.xtm")
  (sys:load "libs/external/gl.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 (impc:aot:insert-forms (sys:load "libs/external/gl.xtm"))
 
 ;; load soil library

--- a/libs/external/stb_image.xtm
+++ b/libs/external/stb_image.xtm
@@ -17,8 +17,8 @@
 (define *xtmlib-stb_image-loaded* #f)
 
 (impc:aot:suppress-aot-do
- (sys:load "libs/core/std.xtm"))
-(impc:aot:insert-forms (sys:load "libs/core/std.xtm" 'quiet))
+ (sys:load "libs/base/base.xtm"))
+(impc:aot:insert-forms (sys:load "libs/base/base.xtm" 'quiet))
 
 (impc:aot:insert-header "xtmstb_image")
 

--- a/src/SchemeProcess.cpp
+++ b/src/SchemeProcess.cpp
@@ -573,9 +573,9 @@ namespace extemp {
                   if (extemp::UNIV::EXT_LOADSTD == 1) {
                     memset(sstr,0,EXT_INITEXPR_BUFLEN);
 #ifdef _WIN32
-					_snprintf(sstr,EXT_INITEXPR_BUFLEN,"(sys:load \"libs/core/std.xtm\" 'quiet)");
+					_snprintf(sstr,EXT_INITEXPR_BUFLEN,"(sys:load \"libs/base/base.xtm\" 'quiet)");
 #else
-                    snprintf(sstr,EXT_INITEXPR_BUFLEN,"(sys:load \"libs/core/std.xtm\" 'quiet)");
+                    snprintf(sstr,EXT_INITEXPR_BUFLEN,"(sys:load \"libs/base/base.xtm\" 'quiet)");
 #endif
                     std::string* s4 = new std::string(sstr);
                     guard.lock();


### PR DESCRIPTION
This PR renames libs/core/std.xtm to libs/base/base.xtm, renames all dependent lib files, and extempore auto loads base.xtm instead of std.xtm.

Integrations tests pass.