### PR TITLE
Added explicit search of LD_LIBRARY_PATH into (bind-dylib path) becau…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,8 +410,8 @@ if(WIN32)
     PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 elseif(APPLE) # OSX
   # use clang++ by default
-  set(CMAKE_C_COMPILIER clang)
-  set(CMAKE_CXX_COMPILIER clang++)
+  set(CMAKE_C_COMPILER clang)
+  set(CMAKE_CXX_COMPILER clang++)
   # tell the compiler about the few ObjC++ source files on OSX
   set_source_files_properties(
     src/Extempore.cpp

--- a/runtime/llvmti.xtm
+++ b/runtime/llvmti.xtm
@@ -9149,6 +9149,7 @@ xtlang's `let' syntax is the same as Scheme"
     (let loop ((rel-paths
                 (list
                  path
+								 (sanitize-platform-path (string-append (sys:command-output "echo $LD_LIBRARY_PATH") "/" path))
                  (sanitize-platform-path (string-append (sys:share-dir) "/libs/aot-cache/" path))
                  (sanitize-platform-path (string-append (sys:share-dir) "/libs/platform-shlibs/" path)))))
       (if (null? rel-paths)

--- a/src/Scheme.cpp
+++ b/src/Scheme.cpp
@@ -1385,9 +1385,9 @@ static int alloc_cellseg(scheme *sc, int n) {
 		
     char str[256];
     //    sprintf(str,"Allocated: %d cell segements for a total of %d.  Free cells = %lld",n,sc->last_cell_seg,sc->fcells);
-    sprintf(str,"Allocated: %d cell segements for a total of %d.",n,sc->last_cell_seg);
+    sprintf(str,"Allocated: %d cell segments for a total of %d.",n,sc->last_cell_seg);
     //CPPBridge::notification(str);
-    std::cout << "Allocated: " << n << " Cell Segements For A Total Of " << sc->last_cell_seg << ",  Free Cells = " << sc->fcells << std::endl;
+    std::cout << "Allocated: " << n << " Cell Segments For A Total Of " << sc->last_cell_seg << ",  Free Cells = " << sc->fcells << std::endl;
     return n;
 }
 


### PR DESCRIPTION
…se dlopen isnt searching it on OSX 10.9.  Also fixed a couple of typos

![git_stuffed](https://cloud.githubusercontent.com/assets/679448/12083306/5e13c344-b2ec-11e5-9dd7-054dedb77da5.png)
