### PR TITLE
Move CMake dependency inside the conditional.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -815,9 +815,9 @@ if(BUILD_DEPS)
       WORKING_DIRECTORY ${EXT_DEPS_INSTALL_DIR})
   endif()
 
-endif(BUILD_DEPS)
-
 add_dependencies(aot_extended extended_deps)
+
+endif(BUILD_DEPS)
 
 #########
 # tests #


### PR DESCRIPTION
While trying to build Extempore as a NixOS package, I got the following error when passing in `-DBUILD_DEPS=OFF`:

```
CMake Error at CMakeLists.txt:876 (add_dependencies):
  The dependency target "extended_deps" of target "aot_extended" does not
  exist.
```

I'm new to Extempore and CMake, so I could be totally misunderstanding what's going on, but this seems to fix the error message.