### PR TITLE
shader #version 330

### DIFF
--- a/libs/external/graphics-pipeline-scm.xtm
+++ b/libs/external/graphics-pipeline-scm.xtm
@@ -314,7 +314,7 @@ void main() {
 
 (define particles-frag
 "//  FRAGMENT SHADER
-#version 400
+#version 330
 
 #extension GL_ARB_texture_rectangle : disable
 
@@ -330,7 +330,7 @@ void main() {
 
 (define green-frag
 "//  FRAGMENT SHADER
-#version 400
+#version 330
 
 #extension GL_ARB_texture_rectangle : enable
 
@@ -361,7 +361,7 @@ void main() {
 
 ;; (define dof-frag
 ;;   "
-;; #version 400
+;; #version 330
 
 ;; #extension GL_ARB_texture_rectangle : enable
 
@@ -415,7 +415,7 @@ void main() {
 
 (define light-vert
   "
-#version 400
+#version 330
 
 out vec3 N, L, E, V;
 out float D;
@@ -447,7 +447,7 @@ void main()
 
 (define light-frag
   "
-#version 400
+#version 330
 
 in vec3 N, L, E, V;
 in float D;
@@ -518,7 +518,7 @@ void main()
 
 (define simple-vert
   "
-#version 400
+#version 330
 
 uniform mat4 ModelMatrix;
 uniform mat4 ViewMatrix;
@@ -534,7 +534,7 @@ void main() {
 
 (define simple-vert-xtm
   "
-#version 400
+#version 330
 
 uniform mat4 ModelMatrix;
 uniform mat4 ViewMatrix;
@@ -555,7 +555,7 @@ void main() {
 
 (define simple-bone-vert-xtm
   "
-#version 400
+#version 330
 
 uniform mat4 ModelMatrix;
 uniform mat4 ViewMatrix;
@@ -621,7 +621,7 @@ void main() {
 
 (define simple-frag
   "
-#version 400
+#version 330
 
 out vec4 xtmColor;
 
@@ -632,7 +632,7 @@ void main() {
 
 (define quad-vert
   "
-#version 400
+#version 330
 
 uniform mat4 ModelMatrix;
 uniform mat4 ViewMatrix;
@@ -656,7 +656,7 @@ void main() {
 
 (define quad-frag
   "
-#version 400
+#version 330
 
 uniform sampler2D tex1;
 in vec2 UVCoord;
@@ -715,7 +715,7 @@ void main()
 
 (define light-and-shade-frag
   "
-#version 400
+#version 330
 
 in vec3 N, L, E, V;
 in float D;
@@ -817,7 +817,7 @@ else
 
 (define xtmvert-xtm
   "
-#version 400
+#version 330
 
 layout (location = 0) in vec4 xtmVertex;
 layout (location = 1) in vec3 xtmNormal;
@@ -869,7 +869,7 @@ void main()
 
 (define xtmfrag
   "
-#version 400
+#version 330
 
 in vec3 N, E, V;
 in vec3 L[10];
@@ -993,7 +993,7 @@ void main()
 
 (define xtmfrag_nolight
   "
-#version 400
+#version 330
 
 in vec3 N, E, V;
 in vec3 L[10];
@@ -1061,7 +1061,7 @@ void main()
 
 (define xtmvert0
   "
-#version 400
+#version 330
 
 layout (location = 0) in vec4 xtmVertex;
 layout (location = 1) in vec3 xtmNormal;
@@ -1112,7 +1112,7 @@ void main()
 
 (define xtmvert1
   "
-#version 400
+#version 330
 
 layout (location = 0) in vec4 xtmVertex;
 layout (location = 1) in vec3 xtmNormal;
@@ -1174,7 +1174,7 @@ void main()
 
 (define xtmvertbone1
   "
-#version 400
+#version 330
 
 layout (location = 0) in vec4 xtmVertex;
 layout (location = 1) in vec3 xtmNormal;
@@ -1276,7 +1276,7 @@ void main()
 
 (define xtmfrag0
   "
-#version 400
+#version 330
 
 in vec3 N, E, V;
 //in vec3 L[10];
@@ -1345,7 +1345,7 @@ void main()
 
 (define xtmfrag1
   "
-#version 400
+#version 330
 
 in vec3 N, E, V;
 in vec3 L[10];
@@ -1456,7 +1456,7 @@ void main()
 
 (define xtmvert2
   "
-#version 400
+#version 330
 
 layout (location = 0) in vec4 xtmVertex;
 layout (location = 1) in vec3 xtmNormal;
@@ -1521,7 +1521,7 @@ void main()
 
 (define xtmfrag2
   "
-#version 400
+#version 330
 
 in vec3 N, E, V;
 in vec3 L[10];
@@ -1684,7 +1684,7 @@ void main()
 
 (define xtmvert3
   "
-#version 400
+#version 330
 
 layout (location = 0) in vec4 xtmVertex;
 layout (location = 1) in vec3 xtmNormal;
@@ -1755,7 +1755,7 @@ void main()
 
 (define xtmfrag3
   "
-#version 400
+#version 330
 
 in vec3 N, E, V;
 in vec3 L[10];
@@ -1969,7 +1969,7 @@ void main()
 
 (define xtmvert4
   "
-#version 400
+#version 330
 
 layout (location = 0) in vec4 xtmVertex;
 layout (location = 1) in vec3 xtmNormal;
@@ -2035,7 +2035,7 @@ void main()
 
 (define xtmfrag4
   "
-#version 400
+#version 330
 
 in vec3 N, E, V;
 in vec3 L[10];
@@ -2300,7 +2300,7 @@ void main()
 
 (define xtmvert5
   "
-#version 400
+#version 330
 
 layout (location = 0) in vec4 xtmVertex;
 layout (location = 1) in vec3 xtmNormal;
@@ -2371,7 +2371,7 @@ void main()
 
 (define xtmfrag5
   "
-#version 400
+#version 330
 
 in vec3 N, E, V;
 in vec3 L[10];
@@ -2687,7 +2687,7 @@ void main()
 
 ;; (define dof-frag
 ;; "
-;; #version 400
+;; #version 330
 
 ;; uniform sampler2D dBuf;
 ;; uniform sampler2D cBuf;
@@ -2744,7 +2744,7 @@ void main()
 ;;
 (define dof-frag
   "
-#version 400
+#version 330
 
 uniform sampler2D bgl_RenderedTexture;
 uniform sampler2D bgl_DepthTexture;
@@ -3055,7 +3055,7 @@ void main()
 
 (define lense-flare-frag
   "
-#version 400
+#version 330
 
 float noise(float t)
 {


### PR DESCRIPTION
I can't get GL version 4.0 to work under Ubuntu 16.04, not with stock intel drivers, not with [this PPA](https://launchpad.net/~oibaf/+archive/ubuntu/graphics-drivers). The xtm shaders work fine with `#version 330`. Can we keep them like this until they actually need `#version 400`?