### PR TITLE
small update to example to fix #299

### DIFF
--- a/examples/core/extempore_lang.xtm
+++ b/examples/core/extempore_lang.xtm
@@ -848,11 +848,11 @@
 ;; compiling this will stop the callbacks
 ;;
 ;; of course we need to keep the type
-;; signature the same [i1,i64,i64]*
+;; signature the same [void,i64,i64]*
 ;;
 (bind-func test34
   (lambda (time:i64 count:i64)
-    #t))
+    void))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
not sure if you prefer adding a return to the previous closure or changing this one to void. thought this one would be nicer and it'd be the 1st time void would be explicitly introduced in a closure type signature