### PR TITLE
Rename 'mmul' to 'mmmul'

### DIFF
--- a/libs/core/math_ext.xtm
+++ b/libs/core/math_ext.xtm
@@ -158,7 +158,7 @@
 (bind-func xtm_multiplication:[Matrix:<!a,i64,i64,i1>*,Matrix:<!a,i64,i64,i1>*,Matrix:<!a,i64,i64,i1>*]*
   (lambda (m1 m2)
     (let ((mdat (alloc (* (tref m1 1) (tref m2 2)))))
-      (mmul (tref m1 0) (tref m1 1) (tref m1 2)
+      (mmmul (tref m1 0) (tref m1 1) (tref m1 2)
             (tref m2 0) (tref m2 1) (tref m2 2)
             mdat)
       (Matrix mdat (tref m1 1) (tref m2 2) (tref m1 3)))))
@@ -167,7 +167,7 @@
 (bind-func xtm_multiplication:[Matrix:<!a,i64,i64,i1>*,Vector:<!a,i64>*,Matrix:<!a,i64,i64,i1>*]*
   (lambda (v1 m2)
     (let ((mdat (alloc (* 1 (tref m2 2)))))
-      (mmul (tref v1 0) 1 (tref v1 1)
+      (mmmul (tref v1 0) 1 (tref v1 1)
             (tref m2 0) (tref m2 1) (tref m2 2)
             mdat)
       (Matrix mdat 1 (tref m2 2) (tref m2 3)))))
@@ -176,7 +176,7 @@
 (bind-func xtm_multiplication:[Matrix:<!a,i64,i64,i1>*,Matrix:<!a,i64,i64,i1>*,Vector:<!a,i64>*]*
   (lambda (m1 v2)
     (let ((mdat (alloc (* (tref m1 1) 1))))
-      (mmul (tref m1 0) (tref m1 1) (tref m1 2)
+      (mmmul (tref m1 0) (tref m1 1) (tref m1 2)
             (tref v2 0) (tref v2 1) 1
             mdat)
       (Matrix mdat (tref m1 1) 1 (tref m1 3)))))


### PR DESCRIPTION
In "math_ext.xtm" there are calls to 'mmul' but the corresponding functions in "math.xtm" are 'mmmul'.
Not sure about the best number of 'm's but this makes it work.