### PR TITLE
Fix llvm build with new gcc

### DIFF
--- a/extras/extempore-llvm-3.8.0.patch
+++ b/extras/extempore-llvm-3.8.0.patch
@@ -35,3 +35,14 @@
        break;
      }
    }
+--- include/llvm/IR/ValueMap.h	2015-08-04 00:30:24.000000000 +0200
++++ include/llvm/IR/ValueMap.h	2018-07-14 21:09:09.769502736 +0200
+@@ -99,7 +99,7 @@
+   explicit ValueMap(const ExtraData &Data, unsigned NumInitBuckets = 64)
+       : Map(NumInitBuckets), Data(Data) {}
+ 
+-  bool hasMD() const { return MDMap; }
++  bool hasMD() const { return static_cast<bool>(MDMap); }
+   MDMapT &MD() {
+     if (!MDMap)
+       MDMap.reset(new MDMapT);


### PR DESCRIPTION
It turns out unique_ptr conversion to bool operator is declared
explicit.

Fixes #318