### PR TITLE
levenshtein: actually compare s1 and s2

### DIFF
--- a/libs/base/base.xtm
+++ b/libs/base/base.xtm
@@ -740,8 +740,8 @@ If both strings are null an empty String will be returned
           ;; column-major indexing closure
           (s1cstr (cstring s1))
           (s1len:size_t (length s1))
-          (s2cstr (cstring s1))
-          (s2len:size_t (length s1))
+          (s2cstr (cstring s2))
+          (s2len:size_t (length s2))
           (row:i64* (salloc (+ s1len 1)))
           (prev_row:i64* (salloc (+ s1len 1)))
           (min3 (lambda (a:i64 b c)


### PR DESCRIPTION
This PR fixes #312. The problem was that the algorithm actually compared `s1` to `s1` instead of `s2`.

Cheers