### PR TITLE
Fix AOT partial rebuilds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,40 +598,53 @@ if(WIN32)
 else(WIN32)
 
   # this approach requires specifying the inter-lib dependencies by hand, but
-  # allows us to do AOT compilation in parallell
+  # allows us to do AOT compilation in parallel
 
   set(EXTEMPORE_AOT_COMPILE_PORT 17099)
+  set(AOT_DIR ${CMAKE_SOURCE_DIR}/libs/aot-cache)
 
-  macro(aotcompile_lib libfile group) # deps are optional, and go at the end
+  function(aotcompile_lib libfile group) # deps are optional, and go at the end
     get_filename_component(basename ${libfile} NAME_WE)
     set(targetname aot_${basename})
-    set(filename ${CMAKE_SOURCE_DIR}/libs/aot-cache/xtm${basename}.so)
+    set(filename ${AOT_DIR}/xtm${basename}.so)
+
+    set(file_deps ${libfile})
+    set(target_deps)
+    foreach(dep ${ARGN})
+      set(file_deps ${file_deps} ${AOT_DIR}/xtm${dep}.so)
+      set(target_deps ${target_deps} aot_${dep})
+    endforeach()
+
     if(PACKAGE)
       add_custom_command (OUTPUT ${filename}
         COMMAND extempore --nobase --noaudio --mcpu=generic --attr=none --port=${EXTEMPORE_AOT_COMPILE_PORT}
         --eval "(impc:aot:compile-xtm-file \"${libfile}\")"
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        DEPENDS ${file_deps}
         VERBATIM)
     else(PACKAGE)
       add_custom_command(OUTPUT ${filename}
         COMMAND extempore --nobase --noaudio --port=${EXTEMPORE_AOT_COMPILE_PORT}
         --eval "(impc:aot:compile-xtm-file \"${libfile}\")"
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        DEPENDS ${file_deps}
         VERBATIM)
     endif(PACKAGE)
+
     add_custom_target(${targetname}
-      DEPENDS ${filename} extempore)
+      DEPENDS ${filename} ${target_deps} extempore)
+
     set_target_properties(${targetname} PROPERTIES FOLDER AOT)
+
     if(NOT ${group} STREQUAL "core")
       add_dependencies(${targetname} external_shlibs_${group})
       add_dependencies(aot_external_${group} ${targetname})
     endif()
-    foreach(dep ${ARGN})
-      add_dependencies(${targetname} aot_${dep})
-    endforeach()
+
     # decrement port number by 2
     math(EXPR EXTEMPORE_AOT_COMPILE_PORT "${EXTEMPORE_AOT_COMPILE_PORT} - 2")
-  endmacro(aotcompile_lib)
+    set(EXTEMPORE_AOT_COMPILE_PORT "${EXTEMPORE_AOT_COMPILE_PORT}" PARENT_SCOPE)
+  endfunction(aotcompile_lib)
 
   # core
   add_custom_target(aot_core)


### PR DESCRIPTION
My last PR prevented rebuilds from working properly; this fixes that by making file and target level dependencies explicit.
Only tested on Linux that:
- Clean AOT builds work.
- Changing a file in the AOT dependency tree only builds dependent AOT targets. I managed to teach CMake to spit this out https://i.imgur.com/KP6q7Kk.png which was helpful for testing
- Extempore still runs.