### PR TITLE
Fix Extempore documentation url

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Check out these videos:
 
 # Docs & Community
 
-Extempore documentation can be found at http://digego.github.io/extempore/index.html
+Extempore documentation can be found at https://extemporelang.github.io/docs/
 
 You can also join the Extempore community:
 


### PR DESCRIPTION
Extempore documentation link was old page, so I changed to new page.

Please confirm!