### PR TITLE
Make playob and playobs consistent with onbeat?

### DIFF
--- a/libs/core/instruments-scm.xtm
+++ b/libs/core/instruments-scm.xtm
@@ -207,12 +207,12 @@
 
 
 (define-macro (playob o b . args)
-  `(if (= 0 (modulo (+ ,o beat) ,b))
+  `(if (= ,o (+ 1 (modulo beat ,b)))
        (play ,@args)
        #f))
 
 (define-macro (playobs l b . args)
-  `(if (member (modulo beat ,b) ,l)
+  `(if (member (+ 1 (modulo beat ,b)) ,l)
        (play ,@args)
        #f))
 


### PR DESCRIPTION
onbeat? uses the musical convention where the beats in a bar are numbered starting with 1.

playob and playobs were numbering the beats starting with 0. This patch fixes them to use the same numbering as onbeat?