### PR TITLE
Clean up pc:quantize and pc:quantize-low

### DIFF
--- a/libs/core/pc_ivl.xtm
+++ b/libs/core/pc_ivl.xtm
@@ -261,11 +261,11 @@
 ;;
 (define pc:quantize
    (lambda (pitch-in pc)
-      (let loop ((inc 0)
+      (let loop ((offset 0)
                  (pitch (round pitch-in)))
-         (cond ((pc:? (+ pitch inc) pc) (+ pitch inc))
-               ((pc:? (- pitch inc) pc) (- pitch inc))
-               ((< inc 7) (loop (+ inc 1) pitch))
+         (cond ((pc:? (+ pitch offset) pc) (+ pitch offset))
+               ((pc:? (- pitch offset) pc) (- pitch offset))
+               ((< offset 7) (loop (+ offset 1) pitch))
                (else (print-notification "no pc value to quantize to" pitch pc)
                      #f)))))
 
@@ -279,11 +279,11 @@
 ;;
 (define pc:quantize-low
    (lambda (pitch-in pc)
-      (let loop ((inc 0)
+      (let loop ((offset 0)
                  (pitch (round pitch-in)))
-         (cond ((pc:? (- pitch inc) pc) (- pitch inc))
-               ((pc:? (+ pitch inc) pc) (+ pitch inc))
-               ((< inc 7) (loop (+ inc 1) pitch))
+         (cond ((pc:? (- pitch offset) pc) (- pitch offset))
+               ((pc:? (+ pitch offset) pc) (+ pitch offset))
+               ((< offset 7) (loop (+ offset 1) pitch))
                (else (print-notification "no pc value to quantize to" pitch pc)
                      #f)))))
 
@@ -762,7 +762,7 @@
 (define ho2 47)
 (define ho3 48)
 (define ho4 49)
-;; crash cymbols 50-54 
+;; crash cymbols 50-54
 (define cc0 50)
 (define cc1 51)
 (define cc2 52)


### PR DESCRIPTION
Refactoring!

I think that "offset" is more appropriate for variable than "inc".
(In the case of similar processing, even in other files, "offset" is used.)

Please confirm!