### PR TITLE
Clean up pc:relative

### DIFF
--- a/libs/core/pc_ivl.xtm
+++ b/libs/core/pc_ivl.xtm
@@ -320,11 +320,11 @@
   (lambda (pitch i pc)
     (set! i (real->integer (round i)))
     (if (= i 0) pitch
-	(let ((inc (if (negative? i) - +)))
-	  (let loop ((p (inc pitch 1)) (cnt 0))
-	    (if (pc:? p pc) (set! cnt (inc cnt 1)))
+	(let ((cnt_op (if (negative? i) - +)))
+	  (let loop ((p (cnt_op pitch 1)) (cnt 0))
+	    (if (pc:? p pc) (set! cnt (cnt_op cnt 1)))
 	    (if (= cnt i) p
-		(loop (inc p 1) cnt)))))))
+		(loop (cnt_op p 1) cnt)))))))
 
 ;; pc:make-chord
 ;; creates a list of "number" pitches between "lower" and "upper"
@@ -762,7 +762,7 @@
 (define ho2 47)
 (define ho3 48)
 (define ho4 49)
-;; crash cymbols 50-54 
+;; crash cymbols 50-54
 (define cc0 50)
 (define cc1 51)
 (define cc2 52)


### PR DESCRIPTION
Refactoring!

I think that "cnt_op"(counter operation) is more appropriate for variable than "inc".
Because, "inc" variable will be set "+" or "-", so if "-" is set, variable name "inc" is unsuitable. 

Please confirm!