### PR TITLE
Update pc:quantize function

### DIFF
--- a/libs/core/pc_ivl.xtm
+++ b/libs/core/pc_ivl.xtm
@@ -262,7 +262,7 @@
 (define pc:quantize
    (lambda (pitch-in pc)
       (let loop ((offset 0)
-                 (pitch (round pitch-in)))
+                 (pitch (real->integer (round pitch-in))))
          (cond ((pc:? (+ pitch offset) pc) (+ pitch offset))
                ((pc:? (- pitch offset) pc) (- pitch offset))
                ((< offset 7) (loop (+ offset 1) pitch))
@@ -280,7 +280,7 @@
 (define pc:quantize-low
    (lambda (pitch-in pc)
       (let loop ((offset 0)
-                 (pitch (round pitch-in)))
+                 (pitch (real->integer (round pitch-in))))
          (cond ((pc:? (- pitch offset) pc) (- pitch offset))
                ((pc:? (+ pitch offset) pc) (+ pitch offset))
                ((< offset 7) (loop (+ offset 1) pitch))


### PR DESCRIPTION
Before, pc:quantize function returns a real type pitch.

```lisp
(pc:quantize 60 '(2 4 8) => 62.0000)
```

But, I think it would be better to return an integer type. 
Because, pitch is represented by integer.

```lisp
(pc:quantize 60 '(2 4 8) => 62)
```

Please review!