### PR TITLE
Clean up pc:move-chord function

### DIFF
--- a/libs/core/pc_ivl.xtm
+++ b/libs/core/pc_ivl.xtm
@@ -616,7 +616,7 @@
 
 ;; find shortest part movement from chord to pc
 (define pc:move-chord
-   (lambda (chord pc . args)
+   (lambda (chord pc)
       (let loop ((pci pc)
                  (chda chord)
                  (chdb '()))


### PR DESCRIPTION
pc:move-chord function optional argument ```args``` doesn't use in body.
So, optional argument ```args``` doesn't need, does it?

Please review!