### PR TITLE
Fix pc:expand/contract function

### DIFF
--- a/libs/core/pc_ivl.xtm
+++ b/libs/core/pc_ivl.xtm
@@ -440,7 +440,7 @@
       (pc:quantize-list (ivl:transpose val lst) pc)))
 
 ;; expand/contract lst by factor quantizing to pc
-(define ivl:expand/contract
+(define pc:expand/contract
    (lambda (lst factor pc)
       (pc:quantize-list (ivl:expand/contract lst factor) pc)))
 


### PR DESCRIPTION
Fixed typo.
(The ivl:expand/contract function is  previous defined.)

Please review!