### PR TITLE
Fix load-sampler function

### DIFF
--- a/libs/external/instruments_ext-scm.xtm
+++ b/libs/external/instruments_ext-scm.xtm
@@ -40,7 +40,7 @@
         (parser (if (> (length args) 1) (cadr args) 'parse-sample-names))
         (midioffset (if (> (length args) 2) (caddr args) 0)))
     `(let ((cnt 0)
-           (file-list (sys:directory-list ,(sys:expand-path path))))
+           (file-list (sys:directory-list (sys:expand-path ,path))))
        (for-each (lambda (samp-data)
                    (if samp-data
                        (begin
@@ -48,7 +48,7 @@
                          (set-sampler-index ,sampler
                                             (if (string=? (sys:platform) "Windows")
                                                 (car samp-data)
-                                                (string-append ,(sys:expand-path path) "/" (car samp-data)))
+                                                (string-append (sys:expand-path ,path) "/" (car samp-data)))
                                             (+ ,midioffset (cadr samp-data))
                                             (caddr samp-data)
                                             (cadddr samp-data)


### PR DESCRIPTION
When I evaluated following code,
```
(define fpath  "./libs/piano/SalamanderGrandPianoV2_44.1khz16bit/44.1khz16bit")
(load-sampler piano
              fpath
              0
              parse-salamander-piano)
```
following error was displayed.

```
Error: evaluating expr: (load-sampler piano
              fpath
              0
              parse-salamander-piano)
stack-catch: ()
stack-catch: ()
stack-catch: ()
stack-catch: ()
stack-catch: ()
stack-catch: ()
stack-catch: ()
stack-catch: ()
stack-catch: ()
stack-catch: ()
Attempting to return a string from a non-string obj fpath
```

Maybe, there is a slight mistake in the macro.
So, fixed.

Please review!