### PR TITLE
Fix type error of nanovg wrapper

### DIFF
--- a/libs/external/nanovg.xtm
+++ b/libs/external/nanovg.xtm
@@ -296,16 +296,16 @@
 ;; Current render style can be saved and restored using nvgSave() and nvgRestore().
 
 ;; Sets current stroke style to a solid color.
-(bind-lib libnanovg nvgStrokeColor [void,NVGcontext*,NVGcolor*]*)
+(bind-lib libnanovg nvgStrokeColor [void,NVGcontext*,NVGcolor]*)
 
 ;; Sets current stroke style to a paint, which can be a one of the gradients or a pattern.
-(bind-lib libnanovg nvgStrokePaint [void,NVGcontext*,NVGpaint*]*)
+(bind-lib libnanovg nvgStrokePaint [void,NVGcontext*,NVGpaint]*)
 
 ;; Sets current fill style to a solid color.
-(bind-lib libnanovg nvgFillColor [void,NVGcontext*,NVGcolor*]*)
+(bind-lib libnanovg nvgFillColor [void,NVGcontext*,NVGcolor]*)
 
 ;; Sets current fill style to a paint, which can be a one of the gradients or a pattern.
-(bind-lib libnanovg nvgFillPaint [void,NVGcontext*,NVGpaint*]*)
+(bind-lib libnanovg nvgFillPaint [void,NVGcontext*,NVGpaint]*)
 
 ;; Sets the miter limit of the stroke style.
 ;; Miter limit controls when a sharp corner is beveled.
@@ -451,24 +451,24 @@
 ;; Creates and returns a linear gradient. Parameters (sx,sy)-(ex,ey) specify the start and end coordinates
 ;; of the linear gradient, icol specifies the start color and ocol the end color.
 ;; The gradient is transformed by the current transform when it is passed to nvgFillPaint() or nvgStrokePaint().
-(bind-lib libnanovg nvgLinearGradient [NVGpaint*,NVGcontext*,float,float,float,float,NVGcolor*,NVGcolor*]*)
+(bind-lib libnanovg nvgLinearGradient [NVGpaint,NVGcontext*,float,float,float,float,NVGcolor,NVGcolor]*)
 
 ;; Creates and returns a box gradient. Box gradient is a feathered rounded rectangle, it is useful for rendering
 ;; drop shadows or highlights for boxes. Parameters (x,y) define the top-left corner of the rectangle,
 ;; (w,h) define the size of the rectangle, r defines the corner radius, and f feather. Feather defines how blurry
 ;; the border of the rectangle is. Parameter icol specifies the inner color and ocol the outer color of the gradient.
 ;; The gradient is transformed by the current transform when it is passed to nvgFillPaint() or nvgStrokePaint().
-(bind-lib libnanovg nvgBoxGradient [NVGpaint*,NVGcontext*,float,float,float,float,float,float,NVGcolor*,NVGcolor*]*)
+(bind-lib libnanovg nvgBoxGradient [NVGpaint,NVGcontext*,float,float,float,float,float,float,NVGcolor,NVGcolor]*)
 
 ;; Creates and returns a radial gradient. Parameters (cx,cy) specify the center, inr and outr specify
 ;; the inner and outer radius of the gradient, icol specifies the start color and ocol the end color.
 ;; The gradient is transformed by the current transform when it is passed to nvgFillPaint() or nvgStrokePaint().
-(bind-lib libnanovg nvgRadialGradient [NVGpaint*,NVGcontext*,float,float,float,float,NVGcolor*,NVGcolor*]*)
+(bind-lib libnanovg nvgRadialGradient [NVGpaint,NVGcontext*,float,float,float,float,NVGcolor,NVGcolor]*)
 
 ;; Creates and returns an image patter. Parameters (ox,oy) specify the left-top location of the image pattern,
 ;; (ex,ey) the size of one image, angle rotation around the top-left corner, image is handle to the image to render.
 ;; The gradient is transformed by the current transform when it is passed to nvgFillPaint() or nvgStrokePaint().
-(bind-lib libnanovg nvgImagePattern [NVGpaint*,NVGcontext*,float,float,float,float,float,i32,float]*)
+(bind-lib libnanovg nvgImagePattern [NVGpaint,NVGcontext*,float,float,float,float,float,i32,float]*)
 
 ;;
 ;; Scissoring


### PR DESCRIPTION
There are some type error of functions return value and arguments.

Example:
[nanovg](https://github.com/memononen/nanovg/blob/master/src/nanovg.h#L245)
```
void nvgStrokeColor(NVGcontext* ctx, NVGcolor color);
```
[Before fixed]
```
(bind-lib libnanovg nvgStrokeColor [void,NVGcontext*,NVGcolor*]*)
```
[After fixed]
```
(bind-lib libnanovg nvgStrokeColor [void,NVGcontext*,NVGcolor]*)
```
The second argument is ```NVGcolor``` type(not pointer).

Please review!  


