### PR TITLE
Handle #f in pc:make-chord

### DIFF
--- a/libs/core/pc_ivl.xtm
+++ b/libs/core/pc_ivl.xtm
@@ -384,7 +384,7 @@
                 (let* ((range (- u l))
                        (gap (round (/ range n)))
                        (pitch (pc:random l (+ l gap) p)))
-                   (if (not (number? pitch)) ; if new pitch is #f try from whole range
+                   (if (not pitch) ; if new pitch is #f, try from whole range
                        (set! chord (cons (pc:random lower upper p) chord))
                        (set! chord (cons pitch chord)))
                    (loop (+ l gap)

--- a/libs/core/pc_ivl.xtm
+++ b/libs/core/pc_ivl.xtm
@@ -384,7 +384,7 @@
                 (let* ((range (- u l))
                        (gap (round (/ range n)))
                        (pitch (pc:random l (+ l gap) p)))
-                   (if (< pitch 0) ; if new pitch is -1 try from whole range
+                   (if (not (number? pitch)) ; if new pitch is #f try from whole range
                        (set! chord (cons (pc:random lower upper p) chord))
                        (set! chord (cons pitch chord)))
                    (loop (+ l gap)


### PR DESCRIPTION
It's likely that this isn't the correct way to do this (I'm still quite new to Scheme), but currently `pc:random` can return either a number or `#f`, which results in `pc:make-cord` breaking often (some configurations break always, some break randomly, some always succeed).

This change just checks if `pitch` is a number before attempting to cons it with the chord, instead of checking that it's greater than `0`.