### PR TITLE
Fix oscillator macros

### DIFF
--- a/libs/core/music.xtm
+++ b/libs/core/music.xtm
@@ -28,14 +28,14 @@
 
 (bind-macro
  ""
- (sinr args)
+ (sinr . args)
  (if (> (length args) 3)
      `(+ ,(cadr args) (* ,(caddr args) (sin (* TWOPI (+ beat ,(car args)) ,(car (cdddr args))))))
      `(+ ,(car args) (* ,(cadr args) (sin (* TWOPI beat ,(caddr args)))))))
 
 (bind-macro
  ""
- (tanr args)
+ (tanr . args)
  (if (> (length args) 3)
      `(+ ,(cadr args) (* ,(caddr args) (tan (* TWOPI (+ beat ,(car args)) ,(car (cdddr args))))))
      `(+ ,(car args) (* ,(cadr args) (tan (* TWOPI beat ,(caddr args)))))))
@@ -60,7 +60,7 @@
 
 (bind-macro
  ""
- (rectr args)
+ (rectr . args)
    (if (> (length args) 3)
        `(+ ,(cadr args) (* ,(caddr args) (rect (* TWOPI (+ beat ,(car args)) ,(car (cdddr args))))))
        `(+ ,(car args) (* ,(cadr args) (rect (* TWOPI beat ,(caddr args)))))))


### PR DESCRIPTION
A few macros were missing the dot notation required in the definition.
This was giving compiler errors.