### PR TITLE
Fix build error involving libsndfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -693,7 +693,8 @@ if(UNIX)
     -DCMAKE_INSTALL_LIBDIR=lib
     -DENABLE_CPACK=OFF
     -DENABLE_PACKAGE_CONFIG=OFF
-    -DBUILD_SHARED_LIBS=ON)
+    -DBUILD_SHARED_LIBS=ON
+    -DBUILD_PROGRAMS=OFF)
     set_target_properties(sndfile PROPERTIES FOLDER EXTERNAL_SHLIBS)
 
     add_custom_target(aot_external_audio ALL)


### PR DESCRIPTION
Fixes #365.
The issue is present upstream: https://github.com/erikd/libsndfile/issues/489
It happens while building libsndfile's programs with `BUILD_SHARED_LIBS=ON`.  
For Extempore, we only need the libsndfile library, not the programs. Not attempting to build them fixes the issue.