### PR TITLE
building.md: archlinux aur package update

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -16,6 +16,12 @@ For platform-specific deps, see "Platform-specific notes" below.
 
 See the top of `CMakeLists.txt` for all the available build options.
 
+### Assets
+
+~500MB Assets (required in many examples) are downloaded if you set `-DASSETS=ON` in cmake command.
+Repository is [here](https://github.com/extemporelang/extempore-assets)
+
+
 ## Targets
 
 The default target will build Extempore, all the dependencies, and AOT-compile
@@ -30,11 +36,6 @@ following targets might come in handy:
   i.e. the pure-xtlang libraries with no external C library dependencies
 
 - the `clean_aot` target will remove all AOT-compiled files
-
-- the `assets` target won't build anything per. se., but it will download the
-  assets e.g. sound files, 3D model files which are referenced in the examples
-  (it's pretty big, so make sure you're on an internet connection where you
-  don't mind downloading a bunch of data)
 
 ## Platform-specific notes
 
@@ -80,10 +81,7 @@ On Ubuntu 18.04-20.04 you can get the required deps with:
 
 #### Arch
 
-There's an [AUR package](https://aur.archlinux.org/packages/extempore-git/) but
-it's currently out-of-date; [@Lapin0t](https://github.com/Lapin0t/extempore-aur)
-has updated the [build script](https://github.com/Lapin0t/extempore-aur) (March
-2020) which _might_ help, ymmv.
+There's an [AUR package](https://aur.archlinux.org/packages/extempore-git/)
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ you go.
 
 ### Build from source
 
+**For more information**, check out [BUILDING.md](./BUILDING.md).
+
 Extempore's CMake build process downloads and build all the dependencies you
 need (including LLVM). So, if you've got a C++ compiler, git and CMake, here are
 some one-liner build commands:
@@ -44,8 +46,6 @@ _Note:_ in the above one-liners the `ASSETS` build-time option (boolean, default
 for many of the examples, but adds a ~300MB download to build process. If you'd
 rather not do that, and are happy with some of the examples not working, then
 set `-DASSETS=OFF` instead.
-
-For more information, check out `BUILDING.md`.
 
 ## See Extempore in action
 


### PR DESCRIPTION
archlinux aur package by @Lapin0t was blocked to ~150 commits ago, downloading it's fork of extempore that had a cmake fix that it's not required anymore. arch users should be used to read aur comments (I think so) so I commented it with an updated PKGBUILD and flagged the package out-of-date (probably the package maintainer didn't know). also assets it's not anymore a target, it's an option now