### PR TITLE
Remove double evaluation

### DIFF
--- a/libs/core/test.xtm
+++ b/libs/core/test.xtm
@@ -105,7 +105,7 @@
      (print-with-colors 'black 'cyan #t (print "" func-sym ""))
      (println)
      (catch (xtmtest-update-test-result func-sym ',call 'compile #f #f)
-            (let ((result (eval ,call (interaction-environment))))
+            (let ((result (eval ',call (interaction-environment))))
               (if (equal? ,expected-result result)
                   (xtmtest-update-test-result func-sym 'correct ',call ,expected-result result)
                   (xtmtest-update-test-result func-sym 'incorrect ',call ,expected-result result))))))


### PR DESCRIPTION
If the function under tests returns a self-evaluating value, all is fine, but something like:

```scheme
(xtmtest-result (list 1 2 3) '(1 2 3)) 
```

falls over in a heap because `(1 2 3)` doesn't evaluate to anything meaningful. There appear to be other double evaluation issues in play, but if I change them all, 'tests/all.xtm' starts failing; I think because there's some fun going on with the interaction between the evaluation environment and the current environment.

It seems that for really good test separation, it might make sense to do something like:

```scheme
(let ((test-environment
       (eval '(let () (current-environment)) (interaction-environment))))
  ...)
```

Which should prevent bindings leaking from one test to the next