### PR TITLE
Fix example test function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1047,7 +1047,7 @@ if(BUILD_TESTS)
 
   macro(extempore_add_example_as_test examplefile timeout label)
     add_test(NAME ${examplefile}
-      COMMAND extempore --noaudio --term nocolor --port=${EXTEMPORE_TEST_PORT} --eval "(sys:load-then-quit \"${examplefile}\" ${timeout})")
+      COMMAND extempore --noaudio --term nocolor --port=${EXTEMPORE_TEST_PORT} --eval "(sys:load-then-quit \"${examplefile}\")")
     set_tests_properties(${examplefile}
       PROPERTIES
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/runtime/scheme.xtm
+++ b/runtime/scheme.xtm
@@ -1801,12 +1801,12 @@
                   (close-port input)
                   #f)))))))
 
-;; load, then wait 10s and quit
+;; load, then quit
 (define sys:load-then-quit
-  (lambda (filename delay-in-sec)
+  (lambda (filename)
     (begin
      (sys:load filename)
-     (callback (+ (now) (* *second* delay-in-sec)) quit 0))))
+     (quit 0)
 
 (define range
   (lambda args


### PR DESCRIPTION
I tried to test using ```make test```. As result, example/* tests  were timeout. (tests/* are OK)

```
 6/41 Test  #6: tests/core/generics.xtm ..................................   Passed   21.81 sec
      Start  7: tests/external/fft.xtm
 7/41 Test  #7: tests/external/fft.xtm ...................................   Passed   14.15 sec
      Start  8: examples/core/audio_101.xtm
 8/41 Test  #8: examples/core/audio_101.xtm ..............................***Timeout 300.04 sec
      Start  9: examples/core/fmsynth.xtm
 9/41 Test  #9: examples/core/fmsynth.xtm ................................***Timeout 300.05 sec
      Start 10: examples/core/mtaudio.xtm
10/41 Test #10: examples/core/mtaudio.xtm ................................***Timeout 300.04 sec
```
Because,```sys:load-then-quit``` function doesn't end until Timeout that set in [CMakeLists.txt](https://github.com/digego/extempore/blob/43a18ee1cae82643fbd45cc3ce67c49f79671426/CMakeLists.txt#L1054)(300 sec) to use callback function.

So, I delete ```callback``` function in ```sys:load-then-quit```. OK?

Please review!