### PR TITLE
[tiny] Add Python 2 to the list of build dependencies

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -9,7 +9,7 @@ in more depth, here's some more information.
 - a C++ compiler (`clang`, `gcc` >= 4.9, `msvc` >= VS2015)
 - Git
 - CMake
-- Python 2
+- Python >= 2.7 (for LLVM)
 
 For platform-specific deps, see "Platform-specific notes" below.
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -9,6 +9,7 @@ in more depth, here's some more information.
 - a C++ compiler (`clang`, `gcc` >= 4.9, `msvc` >= VS2015)
 - Git
 - CMake
+- Python 2
 
 For platform-specific deps, see "Platform-specific notes" below.
 


### PR DESCRIPTION
I ran into this while trying to build on a fresh Windows VM; thought it might be good to add to the doc.