### PR TITLE
Move closure_address_table into its own files + some QOL editor/git things

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,6 +1,10 @@
 ;;; Directory Local Variables
 ;;; For more information see (info "(emacs) Directory Variables")
 
-((extempore-mode
+((c++-mode
+  (indent-tabs-mode)
+  (tab-width . 4)
+  (c-basic-offset . 4))
+ (extempore-mode
   (indent-tabs-mode)
   (tab-width . 2)))

--- a/.gitignore
+++ b/.gitignore
@@ -111,5 +111,8 @@ CMakeSettings.json
 # ignore toml
 /*.toml
 
+# ccls is a clang-based LSP server
+.ccls-cache/*
+
 # ignore config
 config.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,6 +389,7 @@ if (DYLIB)
 
   add_library(extempore SHARED src/Extempore.cpp
     src/AudioDevice.cpp
+    src/EXTClosureAddressTable.cpp
     src/EXTLLVM.cpp
     src/EXTThread.cpp
     src/Extempore.cpp
@@ -404,6 +405,7 @@ if (DYLIB)
 else()
   add_executable(extempore src/Extempore.cpp
     src/AudioDevice.cpp
+    src/EXTClosureAddressTable.cpp
     src/EXTLLVM.cpp
     src/EXTThread.cpp
     src/Extempore.cpp

--- a/include/EXTClosureAddressTable.h
+++ b/include/EXTClosureAddressTable.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace extemp {
+namespace ClosureAddressTable {
+} // namespace ClosureAddressTable
+} // namespace extemp

--- a/include/EXTClosureAddressTable.h
+++ b/include/EXTClosureAddressTable.h
@@ -1,6 +1,27 @@
 #pragma once
 
+#include <UNIV.h>
+
+#include <cinttypes>
+
 namespace extemp {
 namespace ClosureAddressTable {
+    ///////////////////////////////////////////////////////////////////////
+    // This here for Extempore Compiler Runtime.
+    // This is temporary and needs to replaced with something sensible!
+    struct closure_address_table
+    {
+	uint64_t id;
+	char *name;
+	uint32_t offset;
+	char *type;
+	struct closure_address_table *next;
+    };
+
+    EXPORT closure_address_table* get_address_table(const char *name, extemp::ClosureAddressTable::closure_address_table *table);
+
+    EXPORT uint32_t get_address_offset(uint64_t id, closure_address_table* table);
+    EXPORT bool check_address_exists(uint64_t id, closure_address_table* table);
+    EXPORT bool check_address_type(uint64_t id, closure_address_table* table, const char* type);
 } // namespace ClosureAddressTable
 } // namespace extemp

--- a/src/EXTClosureAddressTable.cpp
+++ b/src/EXTClosureAddressTable.cpp
@@ -1,0 +1,1 @@
+#include <EXTClosureAddressTable.h>

--- a/src/EXTClosureAddressTable.cpp
+++ b/src/EXTClosureAddressTable.cpp
@@ -1,1 +1,90 @@
 #include <EXTClosureAddressTable.h>
+#include <EXTLLVM.h>
+
+#include <cstring>
+
+namespace extemp {
+namespace ClosureAddressTable {
+EXPORT closure_address_table * get_address_table(const char *name, closure_address_table *table)
+{
+    while (table) {
+        if (strcmp(table->name, name))
+            return table;
+        table = table->next;
+    }
+    // printf("Unable to locate %s in closure environment a\n", name);
+    return 0;
+}
+
+EXPORT uint32_t get_address_offset(uint64_t id, closure_address_table* table)
+{
+    while(table)
+    {
+        // printf("%p name: %s\ntablename: %s\n\n", name, name, table->name);
+        if(table->id == id) {
+            // printf("in %s returning offset %d from %s\n", table->name, table->offset, name);
+            return table->offset;
+        }
+        table = table->next;
+    }
+    // printf("Unable to locate %" PRIu64 " in closure environment b\n", id);
+    return 0;
+}
+
+EXPORT bool check_address_exists(uint64_t id, closure_address_table* table)
+{
+    do {
+        if (table->id == id) {
+            return true;
+        }
+        table = table->next;
+    } while (table);
+    return false;
+}
+
+EXPORT bool check_address_type(uint64_t id, closure_address_table* table, const char* type)
+{
+    while(table)
+    {
+        if(table->id == id) {
+            if((strcmp(table->type, type)!=0) && (strcmp("{i8*, i8*, void (i8*, i8*)*}**", type) != 0)) {
+                printf("Runtime Type Error: bad type %s for %s. Should be %s\n", type, table->name, table->type);
+                return 0;
+            }
+            else {
+                return 1;
+            }
+        }
+        table = table->next;
+    }
+    // printf("Unable to locate id in closure environment type: %s d\n",type);
+    return 0;
+}
+
+static uint64_t string_hash(const char* str)
+{
+    uint64_t result(0);
+    unsigned char c;
+    while((c = *(str++))) {
+        result = result * 33 + uint8_t(c);
+    }
+    return result;
+}
+
+EXPORT closure_address_table* add_address_table(llvm_zone_t* zone, char* name, uint32_t offset, char* type, int alloctype, struct closure_address_table* table)
+{
+    struct closure_address_table* t = NULL;
+    if (alloctype == 1) {
+        t = reinterpret_cast<closure_address_table*>(malloc(sizeof(struct closure_address_table)));
+    } else {
+        t = (struct closure_address_table*) extemp::EXTLLVM::llvm_zone_malloc(zone,sizeof(struct closure_address_table));
+    }
+    t->id = string_hash(name);
+    t->name = name;
+    t->offset = offset;
+    t->type = type;
+    t->next = table;
+    return t;
+}
+} // namespace ClosureAddressTable
+} // namespace extemp

--- a/src/EXTLLVM.cpp
+++ b/src/EXTLLVM.cpp
@@ -432,8 +432,6 @@ EXPORT float imp_rand2_f(float Start, float Limit)
 
 ///////////////////////////////////
 
-
-
 bool llvm_check_valid_dot_symbol(scheme* sc, char* symbol) {
   char c[1024];
   auto pos(strchr(symbol, '.'));


### PR DESCRIPTION
This PR moves `closure_address_table` into its own files.

The `closure_address_table` code is relatively independent of everything in `EXTLLVM.cpp` so there isn't much reason for it be in there.

I've carved these changes from this larger diff https://github.com/digego/extempore/compare/master...nic-donaldson:llvm-refactor. This PR will help isolate code that touches LLVM, which will later let us move easily from LLVM 3.8 to LLVM 11.