### PR TITLE
Build and cache LLVM 3.8 separately for faster feedback.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,29 +39,19 @@ jobs:
         with:
           path: |
             ./llvm-3.8.0.install
-          key: ${{ matrix.os }}-llvm.3.8.0-1 # bump this number if you want to trigger an LLVM build
+          key: ${{ matrix.os }}-llvm.3.8.0-2 # bump this number if you want to trigger an LLVM build
 
       - name: download and unpack llvm, nixes
         if: steps.llvm-cache.outputs.cache-hit != 'true' && !contains(matrix.os, 'windows')
         run: |
-          wget "https://releases.llvm.org/3.8.0/llvm-3.8.0.src.tar.xz"
+          wget "http://extempore.moso.com.au/extras/llvm-3.8.0.src-patched-for-extempore.tar.xz"
           cmake -E tar xJf llvm-3.8.0.src.tar.xz
 
       - name: download and unpack llvm, windows
         if: contains(matrix.os, 'windows') && steps.llvm-cache.outputs.cache-hit != 'true'
         run: |
-          Invoke-webrequest "https://releases.llvm.org/3.8.0/llvm-3.8.0.src.tar.xz" -outfile llvm-3.8.0.src.tar.xz
+          Invoke-webrequest "http://extempore.moso.com.au/extras/llvm-3.8.0.src-patched-for-extempore.tar.xz"
           cmake -E tar xJf llvm-3.8.0.src.tar.xz
-
-      - uses: actions/checkout@v2
-        with:
-          path: extempore
-
-      - name: patch llvm
-        if: steps.llvm-cache.outputs.cache-hit != 'true'
-        run: |
-          cd llvm-3.8.0.src/
-          patch -p0 -i ../extempore/extras/extempore-llvm-3.8.0.patch
 
       - name: configure llvm
         if: steps.llvm-cache.outputs.cache-hit != 'true'
@@ -92,6 +82,10 @@ jobs:
           cd llvm-3.8.0.build
           cmake --install . --prefix ../llvm-3.8.0.install
           cp .\Release\bin\llvm-as.exe ../llvm-3.8.0.install/bin/
+
+      - uses: actions/checkout@v2
+        with:
+          path: extempore
 
       #- name: configure, nix
       #  if: ${{ !contains(matrix.os, 'windows') }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,6 +51,7 @@ jobs:
         if: contains(matrix.os, 'windows') && steps.llvm-cache.outputs.cache-hit != 'true'
         run: |
           Invoke-webrequest "http://extempore.moso.com.au/extras/llvm-3.8.0.src-patched-for-extempore.tar.xz"
+          ls
           cmake -E tar xJf llvm-3.8.0.src-patched-for-extempore.tar.xz
 
       - name: configure llvm

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -93,31 +93,31 @@ jobs:
           cmake --install . --prefix ../llvm-3.8.0.install
           cp .\Release\bin\llvm-as.exe ../llvm-3.8.0.install/bin/
 
-      - name: configure, nix
-        if: ${{ !contains(matrix.os, 'windows') }}
-        run: cd extempore && mkdir build && cd build && env EXT_LLVM_DIR=$GITHUB_WORKSPACE/llvm-3.8.0.install cmake -DASSETS=ON cmake ${{ matrix.cmake-generator }} ..
+      #- name: configure, nix
+      #  if: ${{ !contains(matrix.os, 'windows') }}
+      #  run: cd extempore && mkdir build && cd build && env EXT_LLVM_DIR=$GITHUB_WORKSPACE/llvm-3.8.0.install cmake -DASSETS=ON cmake ${{ matrix.cmake-generator }} ..
 
-      - name: configure, windows
-        if: contains(matrix.os, 'windows')
-        run: |
-          $Env:EXT_LLVM_DIR = "$Env:GITHUB_WORKSPACE/llvm-3.8.0.install"
-          cd extempore && mkdir build && cd build && cmake -DASSETS=ON ${{ matrix.cmake-generator }} ..
+      #- name: configure, windows
+      #  if: contains(matrix.os, 'windows')
+      #  run: |
+      #    $Env:EXT_LLVM_DIR = "$Env:GITHUB_WORKSPACE/llvm-3.8.0.install"
+      #    cd extempore && mkdir build && cd build && cmake -DASSETS=ON ${{ matrix.cmake-generator }} ..
 
-      - name: build, nix
-        if: ${{ !contains(matrix.os, 'windows') }}
-        run: |
-          cd extempore/build
-          env EXT_LLVM_DIR=$GITHUB_WORKSPACE/llvm-3.8.0.install cmake --build . -j2 --config Release
+      #- name: build, nix
+      #  if: ${{ !contains(matrix.os, 'windows') }}
+      #  run: |
+      #    cd extempore/build
+      #    env EXT_LLVM_DIR=$GITHUB_WORKSPACE/llvm-3.8.0.install cmake --build . -j2 --config Release
 
-      - name: build, windows
-        if: contains(matrix.os, 'windows')
-        run: |
-          cd extempore/build
-          $Env:EXT_LLVM_DIR="$Env:GITHUB_WORKSPACE/llvm-3.8.0.install/Release"
-          cmake --build . -j2 --config Release
+      #- name: build, windows
+      #  if: contains(matrix.os, 'windows')
+      #  run: |
+      #    cd extempore/build
+      #    $Env:EXT_LLVM_DIR="$Env:GITHUB_WORKSPACE/llvm-3.8.0.install/Release"
+      #    cmake --build . -j2 --config Release
 
-      #- name: aot-compile-stdlib
-      #  run: cd extempore && cmake --build build --config ${{ matrix.config }}
+      ##- name: aot-compile-stdlib
+      ##  run: cd extempore && cmake --build build --config ${{ matrix.config }}
 
-      - name: test
-        run: cd extempore && cd build && ctest --build-config ${{ matrix.config }} --label-regex libs-core
+      #- name: test
+      #  run: cd extempore && cd build && ctest --build-config ${{ matrix.config }} --label-regex libs-core

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,9 @@ jobs:
           - windows-2016
           - windows-2019
         config:
-          - Release # If you add Debug, be careful about the LLVM build, you might still want that to be Release.
+          - Release
+          # If you add Debug, be careful about the LLVM build.
+          # LLVM Debug builds take a really long time, and consume a lot of disk space.
         include:
           - os: windows-2016
             cmake-generator: -G "Visual Studio 15 2017" -A x64
@@ -39,7 +41,7 @@ jobs:
         with:
           path: |
             ./llvm-3.8.0.install
-          key: ${{ matrix.os }}-llvm.3.8.0-3 # bump this number if you want to trigger an LLVM build
+          key: ${{ matrix.os }}-${{ matrix.config }}-llvm.3.8.0-0 # bump this number if you want to trigger an LLVM build
 
       - name: download and unpack llvm, nix
         if: steps.llvm-cache.outputs.cache-hit != 'true' && !contains(matrix.os, 'windows')

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
           - windows-2016
           - windows-2019
         config:
-          - Release
+          - Release # If you add Debug, be careful about the LLVM build, you might still want that to be Release.
         include:
           - os: windows-2016
             cmake-generator: -G "Visual Studio 15 2017" -A x64
@@ -97,15 +97,14 @@ jobs:
         with:
           path: extempore
 
-      - name: configure, nix
-        if: ${{ !contains(matrix.os, 'windows') }}
-        run: cd extempore && mkdir build && cd build && env EXT_LLVM_DIR=$GITHUB_WORKSPACE/llvm-3.8.0.install cmake -DASSETS=ON ${{ matrix.cmake-generator }} ..
-
-      - name: configure, windows
-        if: contains(matrix.os, 'windows')
+      - name: configure
+        env:
+          EXT_LLVM_DIR: "${{ env.EXT_LLVM_DIR }}"
         run: |
-          $Env:EXT_LLVM_DIR="$Env:GITHUB_WORKSPACE/llvm-3.8.0.install"
-          cd extempore && mkdir build && cd build && cmake -DASSETS=ON ${{ matrix.cmake-generator }} ..
+          cd extempore
+          mkdir build
+          cd build
+          cmake -DASSETS=ON ${{ matrix.cmake-generator }} ..
 
       - name: build, nix
         if: ${{ !contains(matrix.os, 'windows') }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           path: |
             ./llvm-3.8.0.install
-          key: ${{ matrix.os }}-llvm.3.8.0-0 # bump this number if you want to trigger an LLVM build
+          key: ${{ matrix.os }}-llvm.3.8.0-1 # bump this number if you want to trigger an LLVM build
 
       - name: download and unpack llvm, nixes
         if: steps.llvm-cache.outputs.cache-hit != 'true' && !contains(matrix.os, 'windows')

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -61,7 +61,7 @@ jobs:
         if: steps.llvm-cache.outputs.cache-hit != 'true'
         run: |
           cd llvm-3.8.0.src/
-          patch -p0 -i $GITHUB_WORKSPACE/extempore/extras/extempore-llvm-3.8.0.patch
+          patch -p0 -i ../extempore/extras/extempore-llvm-3.8.0.patch
 
       - name: configure
         run: cd extempore && mkdir build && cd build && cmake -DASSETS=ON cmake ${{ matrix.cmake-generator }} ..

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,8 +50,9 @@ jobs:
       - name: download and unpack llvm, windows
         if: contains(matrix.os, 'windows') && steps.llvm-cache.outputs.cache-hit != 'true'
         run: |
-          Invoke-webrequest "http://extempore.moso.com.au/extras/llvm-3.8.0.src-patched-for-extempore.tar.xz"
+          Invoke-webrequest -Uri "http://extempore.moso.com.au/extras/llvm-3.8.0.src-patched-for-extempore.tar.xz" -OutFile "llvm-3.8.0.src-patched-for-extempore.tar.xz"
           ls
+          dir
           cmake -E tar xJf llvm-3.8.0.src-patched-for-extempore.tar.xz
 
       - name: configure llvm

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           path: extempore
 
-      # I have no idea why env: seems to work fine above ^, but not here :(
+      # I have no idea why `env:` seems to work for building, but not configuring :(
       - name: configure, nix
         if: ${{ !contains(matrix.os, 'windows') }}
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,8 +27,6 @@ jobs:
             cmake-generator: -G "Visual Studio 16 2019" -A x64
 
     steps:
-      - uses: actions/checkout@v2
-
       - if: contains(matrix.os, 'ubuntu')
         name: deps
         run: |
@@ -55,14 +53,23 @@ jobs:
           Invoke-webrequest "https://releases.llvm.org/3.8.0/llvm-3.8.0.src.tar.xz" -outfile llvm-3.8.0.src.tar.xz
           cmake -E tar xJf llvm-3.8.0.src.tar.xz
 
+      - uses: actions/checkout@v2
+        path: extempore
+
+      - name: patch llvm
+        if: steps.llvm-cache.outputs.cache-hit != 'true'
+        run: |
+          cd llvm-3.8.0.src/
+          patch -p0 -i $GITHUB_WORKSPACE/extempore/extras/extempore-llvm-3.8.0.patch
+
       - name: configure
-        run: mkdir build && cd build && cmake -DASSETS=ON cmake ${{ matrix.cmake-generator }} ..
+        run: cd extempore && mkdir build && cd build && cmake -DASSETS=ON cmake ${{ matrix.cmake-generator }} ..
 
       - name: build
-        run: cmake --build build --target extempore --config ${{ matrix.config }}
+        run: cd extempore && cmake --build build --target extempore --config ${{ matrix.config }}
 
       - name: aot-compile-stdlib
-        run: cmake --build build --config ${{ matrix.config }}
+        run: cd extempore && cmake --build build --config ${{ matrix.config }}
 
       - name: test
-        run: cd build && ctest --build-config ${{ matrix.config }} --label-regex libs-core
+        run: cd extempore && cd build && ctest --build-config ${{ matrix.config }} --label-regex libs-core

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -93,14 +93,29 @@ jobs:
           cmake --install . --prefix ../llvm-3.8.0.install
           cp .\Release\bin\llvm-as.exe ../llvm-3.8.0.install/bin/
 
-      - name: configure
-        run: cd extempore && mkdir build && cd build && cmake -DASSETS=ON cmake ${{ matrix.cmake-generator }} ..
+      - name: configure, nix
+        if: ${{ !contains(matrix.os, 'windows') }}
+        run: cd extempore && mkdir build && cd build && env EXT_LLVM_DIR=$GITHUB_WORKSPACE/llvm-3.8.0.install cmake -DASSETS=ON cmake ${{ matrix.cmake-generator }} ..
 
-      - name: build
-        run: cd extempore && cmake --build build --target extempore --config ${{ matrix.config }}
+      - name: configure, windows
+        if: contains(matrix.os, 'windows')
+        run: |
+          $env:EXT_LLVM_DIR = "$Env:$GITHUB_WORKSPACE/llvm-3.8.0.install"
+          cd extempore && mkdir build && cd build && cmake -DASSETS=ON ${{ matrix.cmake-generator }} ..
 
-      - name: aot-compile-stdlib
-        run: cd extempore && cmake --build build --config ${{ matrix.config }}
+      - name: build, nix
+        run: |
+          cd extempore/build
+          env EXT_LLVM_DIR=$GITHUB_WORKSPACE/llvm-3.8.0.install cmake --build . -j2 --config Release
+
+      - name: build, windows
+        run: |
+          cd extempore/build
+          $Env:EXT_LLVM_DIR="$Env:GITHUB_WORKSPACE/llvm-3.8.0.install/Release"
+          cmake --build . -j2 --config Release
+
+      #- name: aot-compile-stdlib
+      #  run: cd extempore && cmake --build build --config ${{ matrix.config }}
 
       - name: test
         run: cd extempore && cd build && ctest --build-config ${{ matrix.config }} --label-regex libs-core

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -104,11 +104,13 @@ jobs:
           cd extempore && mkdir build && cd build && cmake -DASSETS=ON ${{ matrix.cmake-generator }} ..
 
       - name: build, nix
+        if: ${{ !contains(matrix.os, 'windows') }}
         run: |
           cd extempore/build
           env EXT_LLVM_DIR=$GITHUB_WORKSPACE/llvm-3.8.0.install cmake --build . -j2 --config Release
 
       - name: build, windows
+        if: contains(matrix.os, 'windows')
         run: |
           cd extempore/build
           $Env:EXT_LLVM_DIR="$Env:GITHUB_WORKSPACE/llvm-3.8.0.install/Release"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,13 +43,13 @@ jobs:
             ./llvm-3.8.0.install
           key: ${{ matrix.os }}-${{ matrix.config }}-llvm.3.8.0-0 # bump this number if you want to trigger an LLVM build
 
-      - name: download and unpack llvm, nix
+      - name: download and unpack llvm (macos/linux)
         if: steps.llvm-cache.outputs.cache-hit != 'true' && !contains(matrix.os, 'windows')
         run: |
           wget "http://extempore.moso.com.au/extras/llvm-3.8.0.src-patched-for-extempore.tar.xz"
           cmake -E tar xJf llvm-3.8.0.src-patched-for-extempore.tar.xz
 
-      - name: download and unpack llvm, windows
+      - name: download and unpack llvm (windows)
         if: contains(matrix.os, 'windows') && steps.llvm-cache.outputs.cache-hit != 'true'
         run: |
           Invoke-webrequest -Uri "http://extempore.moso.com.au/extras/llvm-3.8.0.src-patched-for-extempore.tar.xz" -OutFile "llvm-3.8.0.src-patched-for-extempore.tar.xz"
@@ -71,14 +71,14 @@ jobs:
           cmake --build . --config ${{ matrix.config }} -j2
           cmake --build . --config ${{ matrix.config }} -j2 --target llvm-as
 
-      - name: install llvm nix
+      - name: install llvm (macos/linux)
         if: steps.llvm-cache.outputs.cache-hit != 'true' && !contains(matrix.os, 'windows')
         run: |
           cd llvm-3.8.0.build
           cmake --install .
           cp bin/llvm-as $GITHUB_WORKSPACE/llvm-3.8.0.install/bin/
 
-      - name: install llvm windows
+      - name: install llvm (windows)
         if: contains(matrix.os, 'windows') && steps.llvm-cache.outputs.cache-hit != 'true'
         run: |
           cd llvm-3.8.0.build
@@ -90,7 +90,7 @@ jobs:
           path: extempore
 
       # I have no idea why `env:` seems to work for building, but not configuring :(
-      - name: configure, nix
+      - name: configure extempore (macos/linux)
         if: ${{ !contains(matrix.os, 'windows') }}
         run: |
           cd extempore
@@ -98,7 +98,7 @@ jobs:
           cd build
           env EXT_LLVM_DIR=$GITHUB_WORKSPACE/llvm-3.8.0.install cmake -DASSETS=ON ${{ matrix.cmake-generator }} ..
 
-      - name: configure, windows
+      - name: configure extempore (windows)
         if: contains(matrix.os, 'windows')
         run: |
           $Env:EXT_LLVM_DIR="$Env:GITHUB_WORKSPACE/llvm-3.8.0.install"
@@ -107,7 +107,7 @@ jobs:
           cd build
           cmake -DASSETS=ON ${{ matrix.cmake-generator }} ..
 
-      - name: build, nix
+      - name: build extempore (macos/linux)
         if: ${{ !contains(matrix.os, 'windows') }}
         env:
           EXT_LLVM_DIR: "${{ env.GITHUB_WORKSPACE }}/llvm-3.8.0.install"
@@ -115,7 +115,7 @@ jobs:
           cd extempore/build
           cmake --build . -j2 --config ${{ matrix.config }} --target extempore
 
-      - name: build, windows
+      - name: build extempore (windows)
         if: contains(matrix.os, 'windows')
         env:
           EXT_LLVM_DIR: "${{ env.GITHUB_WORKSPACE }}/llvm-3.8.0.install/${{ matrix.config }}"
@@ -123,7 +123,7 @@ jobs:
           cd extempore/build
           cmake --build . -j2 --config ${{ matrix.config }} --target extempore
 
-      - name: aot-compile-stdlib, nix
+      - name: aot-compile-stdlib (macos/linux)
         if: ${{ !contains(matrix.os, 'windows') }}
         env:
           EXT_LLVM_DIR: "${{ env.GITHUB_WORKSPACE }}/llvm-3.8.0.install"
@@ -131,7 +131,7 @@ jobs:
           cd extempore/build
           cmake --build . -j2 --config ${{ matrix.config }}
 
-      - name: aot-compile-stdlib, windows
+      - name: aot-compile-stdlib (windows)
         if: ${{ contains(matrix.os, 'windows') }}
         env:
           EXT_LLVM_DIR: "${{ env.GITHUB_WORKSPACE }}/llvm-3.8.0.install/${{ matrix.config }}"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,8 +51,6 @@ jobs:
         if: contains(matrix.os, 'windows') && steps.llvm-cache.outputs.cache-hit != 'true'
         run: |
           Invoke-webrequest -Uri "http://extempore.moso.com.au/extras/llvm-3.8.0.src-patched-for-extempore.tar.xz" -OutFile "llvm-3.8.0.src-patched-for-extempore.tar.xz"
-          ls
-          dir
           cmake -E tar xJf llvm-3.8.0.src-patched-for-extempore.tar.xz
 
       - name: configure llvm
@@ -61,7 +59,7 @@ jobs:
           mkdir llvm-3.8.0.build
           mkdir llvm-3.8.0.install
           cd llvm-3.8.0.build
-          cmake -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_ZLIB=OFF -DLLVM_INCLUDE_UTILS=OFF -DLLVM_BUILD_RUNTIME=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_GO_TESTS=OFF -DLLVM_INCLUDE_DOCS=OFF -DCMAKE_INSTALL_PREFIX=../llvm-3.8.0.install ../llvm-3.8.0.src/
+          cmake -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_ZLIB=OFF -DLLVM_INCLUDE_UTILS=OFF -DLLVM_BUILD_RUNTIME=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_GO_TESTS=OFF -DLLVM_INCLUDE_DOCS=OFF -DCMAKE_C_FLAGS="" -DCMAKE_CXX_FLAGS="" -DCMAKE_INSTALL_PREFIX=../llvm-3.8.0.install ../llvm-3.8.0.src/
 
       - name: build llvm
         if: steps.llvm-cache.outputs.cache-hit != 'true'
@@ -89,31 +87,31 @@ jobs:
         with:
           path: extempore
 
-      #- name: configure, nix
-      #  if: ${{ !contains(matrix.os, 'windows') }}
-      #  run: cd extempore && mkdir build && cd build && env EXT_LLVM_DIR=$GITHUB_WORKSPACE/llvm-3.8.0.install cmake -DASSETS=ON cmake ${{ matrix.cmake-generator }} ..
+      - name: configure, nix
+        if: ${{ !contains(matrix.os, 'windows') }}
+        run: cd extempore && mkdir build && cd build && env EXT_LLVM_DIR=$GITHUB_WORKSPACE/llvm-3.8.0.install cmake -DASSETS=ON cmake ${{ matrix.cmake-generator }} ..
 
-      #- name: configure, windows
-      #  if: contains(matrix.os, 'windows')
-      #  run: |
-      #    $Env:EXT_LLVM_DIR = "$Env:GITHUB_WORKSPACE/llvm-3.8.0.install"
-      #    cd extempore && mkdir build && cd build && cmake -DASSETS=ON ${{ matrix.cmake-generator }} ..
+      - name: configure, windows
+        if: contains(matrix.os, 'windows')
+        run: |
+          $Env:EXT_LLVM_DIR="$Env:GITHUB_WORKSPACE/llvm-3.8.0.install"
+          cd extempore && mkdir build && cd build && cmake -DASSETS=ON ${{ matrix.cmake-generator }} ..
 
-      #- name: build, nix
-      #  if: ${{ !contains(matrix.os, 'windows') }}
-      #  run: |
-      #    cd extempore/build
-      #    env EXT_LLVM_DIR=$GITHUB_WORKSPACE/llvm-3.8.0.install cmake --build . -j2 --config Release
+      - name: build, nix
+        if: ${{ !contains(matrix.os, 'windows') }}
+        run: |
+          cd extempore/build
+          env EXT_LLVM_DIR=$GITHUB_WORKSPACE/llvm-3.8.0.install cmake --build . -j2 --config Release
 
-      #- name: build, windows
-      #  if: contains(matrix.os, 'windows')
-      #  run: |
-      #    cd extempore/build
-      #    $Env:EXT_LLVM_DIR="$Env:GITHUB_WORKSPACE/llvm-3.8.0.install/Release"
-      #    cmake --build . -j2 --config Release
+      - name: build, windows
+        if: contains(matrix.os, 'windows')
+        run: |
+          cd extempore/build
+          $Env:EXT_LLVM_DIR="$Env:GITHUB_WORKSPACE/llvm-3.8.0.install/Release"
+          cmake --build . -j2 --config Release
 
-      ##- name: aot-compile-stdlib
-      ##  run: cd extempore && cmake --build build --config ${{ matrix.config }}
+      #- name: aot-compile-stdlib
+      #  run: cd extempore && cmake --build build --config ${{ matrix.config }}
 
-      #- name: test
-      #  run: cd extempore && cd build && ctest --build-config ${{ matrix.config }} --label-regex libs-core
+      - name: test
+        run: cd extempore && cd build && ctest --build-config ${{ matrix.config }} --label-regex libs-core

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,23 +83,13 @@ jobs:
           cmake --install . --prefix ../llvm-3.8.0.install
           cp .\${{ matrix.config }}\bin\llvm-as.exe ../llvm-3.8.0.install/bin/
 
-      - name: llvm install path, nix
-        if: ${{ !contains(matrix.os, 'windows') }}
-        run: |
-          echo "EXT_LLVM_DIR=${{ env.GITHUB_WORKSPACE }}/llvm-3.8.0.install" >> $GITHUB_ENV
-
-      - name: llvm install path, windows
-        if: contains(matrix.os, 'windows')
-        run: |
-          echo "EXT_LLVM_DIR=${{ env.GITHUB_WORKSPACE }}/llvm-3.8.0.install/Release" >> $GITHUB_ENV
-
       - uses: actions/checkout@v2
         with:
           path: extempore
 
       - name: configure
         env:
-          EXT_LLVM_DIR: "${{ env.EXT_LLVM_DIR }}"
+          EXT_LLVM_DIR: "${{ env.GITHUB_WORKSPACE }}/llvm-3.8.0.install"
         run: |
           cd extempore
           mkdir build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -59,15 +59,15 @@ jobs:
           mkdir llvm-3.8.0.build
           mkdir llvm-3.8.0.install
           cd llvm-3.8.0.build
-          cmake -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_ZLIB=OFF -DLLVM_INCLUDE_UTILS=OFF -DLLVM_BUILD_RUNTIME=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_GO_TESTS=OFF -DLLVM_INCLUDE_DOCS=OFF -DCMAKE_C_FLAGS="" -DCMAKE_CXX_FLAGS="" -DCMAKE_INSTALL_PREFIX=../llvm-3.8.0.install ${{ matrix.cmake-generator }} ../llvm-3.8.0.src/
+          cmake -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_ZLIB=OFF -DLLVM_INCLUDE_UTILS=OFF -DLLVM_BUILD_RUNTIME=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_GO_TESTS=OFF -DLLVM_INCLUDE_DOCS=OFF -DCMAKE_C_FLAGS="" -DCMAKE_CXX_FLAGS="" -DCMAKE_INSTALL_PREFIX=../llvm-3.8.0.install ${{ matrix.cmake-generator }} ../llvm-3.8.0.src/
 
       - name: build llvm
         if: steps.llvm-cache.outputs.cache-hit != 'true'
         run: |
           cd llvm-3.8.0.build
           # if you're doing this by hand you might need `-- -j2` instead of `-j2`
-          cmake --build . --config Release -j2
-          cmake --build . --config Release -j2 --target llvm-as
+          cmake --build . --config ${{ matrix.config }} -j2
+          cmake --build . --config ${{ matrix.config }} -j2 --target llvm-as
 
       - name: install llvm nix
         if: steps.llvm-cache.outputs.cache-hit != 'true' && !contains(matrix.os, 'windows')
@@ -81,7 +81,17 @@ jobs:
         run: |
           cd llvm-3.8.0.build
           cmake --install . --prefix ../llvm-3.8.0.install
-          cp .\Release\bin\llvm-as.exe ../llvm-3.8.0.install/bin/
+          cp .\${{ matrix.config }}\bin\llvm-as.exe ../llvm-3.8.0.install/bin/
+
+      - name: llvm install path, nix
+        if: ${{ !contains(matrix.os, 'windows') }}
+        run: |
+          echo "EXT_LLVM_DIR=${{ env.GITHUB_WORKSPACE }}/llvm-3.8.0.install" >> $GITHUB_ENV
+
+      - name: llvm install path, windows
+        if: contains(matrix.os, 'windows')
+        run: |
+          echo "EXT_LLVM_DIR=${{ env.GITHUB_WORKSPACE }}/llvm-3.8.0.install/Release" >> $GITHUB_ENV
 
       - uses: actions/checkout@v2
         with:
@@ -103,18 +113,31 @@ jobs:
           EXT_LLVM_DIR: "${{ env.GITHUB_WORKSPACE }}/llvm-3.8.0.install"
         run: |
           cd extempore/build
-          cmake --build . -j2 --config Release
+          cmake --build . -j2 --config ${{ matrix.config }} --target extempore
 
       - name: build, windows
         if: contains(matrix.os, 'windows')
         env:
-          EXT_LLVM_DIR: "${{ env.GITHUB_WORKSPACE }}/llvm-3.8.0.install/Release"
+          EXT_LLVM_DIR: "${{ env.GITHUB_WORKSPACE }}/llvm-3.8.0.install/${{ matrix.config }}"
         run: |
           cd extempore/build
-          cmake --build . -j2 --config Release
+          cmake --build . -j2 --config ${{ matrix.config }} --target extempore
 
-      #- name: aot-compile-stdlib
-      #  run: cd extempore && cmake --build build --config ${{ matrix.config }}
+      - name: aot-compile-stdlib, nix
+        if: ${{ !contains(matrix.os, 'windows') }}
+        env:
+          EXT_LLVM_DIR: "${{ env.GITHUB_WORKSPACE }}/llvm-3.8.0.install"
+        run: |
+          cd extempore/build
+          cmake --build . -j2 --config ${{ matrix.config }}
+
+      - name: aot-compile-stdlib, windows
+        if: ${{ contains(matrix.os, 'windows') }}
+        env:
+          EXT_LLVM_DIR: "${{ env.GITHUB_WORKSPACE }}/llvm-3.8.0.install/${{ matrix.config }}"
+        run: |
+          cd extempore/build
+          cmake --build . -j2 --config ${{ matrix.config }}
 
       - name: test
         run: cd extempore && cd build && ctest --build-config ${{ matrix.config }} --label-regex libs-core

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -99,15 +99,18 @@ jobs:
 
       - name: build, nix
         if: ${{ !contains(matrix.os, 'windows') }}
+        env:
+          EXT_LLVM_DIR: "${{ env.GITHUB_WORKSPACE }}/llvm-3.8.0.install"
         run: |
           cd extempore/build
-          env EXT_LLVM_DIR=$GITHUB_WORKSPACE/llvm-3.8.0.install cmake --build . -j2 --config Release
+          cmake --build . -j2 --config Release
 
       - name: build, windows
         if: contains(matrix.os, 'windows')
+        env:
+          EXT_LLVM_DIR: "${{ env.GITHUB_WORKSPACE }}/llvm-3.8.0.install/Release"
         run: |
           cd extempore/build
-          $Env:EXT_LLVM_DIR="$Env:GITHUB_WORKSPACE/llvm-3.8.0.install/Release"
           cmake --build . -j2 --config Release
 
       #- name: aot-compile-stdlib

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -63,6 +63,14 @@ jobs:
           cd llvm-3.8.0.src/
           patch -p0 -i ../extempore/extras/extempore-llvm-3.8.0.patch
 
+      - name: configure llvm
+        if: steps.llvm-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir llvm-3.8.0.build
+          mkdir llvm-3.8.0.install
+          cd llvm-3.8.0.build
+          cmake -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_ZLIB=OFF -DLLVM_INCLUDE_UTILS=OFF -DLLVM_BUILD_RUNTIME=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_GO_TESTS=OFF -DLLVM_INCLUDE_DOCS=OFF -DCMAKE_INSTALL_PREFIX=../llvm-3.8.0.install ../llvm-3.8.0.src/
+
       - name: configure
         run: cd extempore && mkdir build && cd build && cmake -DASSETS=ON cmake ${{ matrix.cmake-generator }} ..
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,9 +39,9 @@ jobs:
         with:
           path: |
             ./llvm-3.8.0.install
-          key: ${{ matrix.os }}-llvm.3.8.0-2 # bump this number if you want to trigger an LLVM build
+          key: ${{ matrix.os }}-llvm.3.8.0-3 # bump this number if you want to trigger an LLVM build
 
-      - name: download and unpack llvm, nixes
+      - name: download and unpack llvm, nix
         if: steps.llvm-cache.outputs.cache-hit != 'true' && !contains(matrix.os, 'windows')
         run: |
           wget "http://extempore.moso.com.au/extras/llvm-3.8.0.src-patched-for-extempore.tar.xz"
@@ -59,7 +59,7 @@ jobs:
           mkdir llvm-3.8.0.build
           mkdir llvm-3.8.0.install
           cd llvm-3.8.0.build
-          cmake -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_ZLIB=OFF -DLLVM_INCLUDE_UTILS=OFF -DLLVM_BUILD_RUNTIME=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_GO_TESTS=OFF -DLLVM_INCLUDE_DOCS=OFF -DCMAKE_C_FLAGS="" -DCMAKE_CXX_FLAGS="" -DCMAKE_INSTALL_PREFIX=../llvm-3.8.0.install ../llvm-3.8.0.src/
+          cmake -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_ZLIB=OFF -DLLVM_INCLUDE_UTILS=OFF -DLLVM_BUILD_RUNTIME=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_GO_TESTS=OFF -DLLVM_INCLUDE_DOCS=OFF -DCMAKE_C_FLAGS="" -DCMAKE_CXX_FLAGS="" -DCMAKE_INSTALL_PREFIX=../llvm-3.8.0.install ${{ matrix.cmake-generator }} ../llvm-3.8.0.src/
 
       - name: build llvm
         if: steps.llvm-cache.outputs.cache-hit != 'true'
@@ -89,7 +89,7 @@ jobs:
 
       - name: configure, nix
         if: ${{ !contains(matrix.os, 'windows') }}
-        run: cd extempore && mkdir build && cd build && env EXT_LLVM_DIR=$GITHUB_WORKSPACE/llvm-3.8.0.install cmake -DASSETS=ON cmake ${{ matrix.cmake-generator }} ..
+        run: cd extempore && mkdir build && cd build && env EXT_LLVM_DIR=$GITHUB_WORKSPACE/llvm-3.8.0.install cmake -DASSETS=ON ${{ matrix.cmake-generator }} ..
 
       - name: configure, windows
         if: contains(matrix.os, 'windows')

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,13 +45,13 @@ jobs:
         if: steps.llvm-cache.outputs.cache-hit != 'true' && !contains(matrix.os, 'windows')
         run: |
           wget "http://extempore.moso.com.au/extras/llvm-3.8.0.src-patched-for-extempore.tar.xz"
-          cmake -E tar xJf llvm-3.8.0.src.tar.xz
+          cmake -E tar xJf llvm-3.8.0.src-patched-for-extempore.tar.xz
 
       - name: download and unpack llvm, windows
         if: contains(matrix.os, 'windows') && steps.llvm-cache.outputs.cache-hit != 'true'
         run: |
           Invoke-webrequest "http://extempore.moso.com.au/extras/llvm-3.8.0.src-patched-for-extempore.tar.xz"
-          cmake -E tar xJf llvm-3.8.0.src.tar.xz
+          cmake -E tar xJf llvm-3.8.0.src-patched-for-extempore.tar.xz
 
       - name: configure llvm
         if: steps.llvm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -71,6 +71,28 @@ jobs:
           cd llvm-3.8.0.build
           cmake -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_ZLIB=OFF -DLLVM_INCLUDE_UTILS=OFF -DLLVM_BUILD_RUNTIME=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_GO_TESTS=OFF -DLLVM_INCLUDE_DOCS=OFF -DCMAKE_INSTALL_PREFIX=../llvm-3.8.0.install ../llvm-3.8.0.src/
 
+      - name: build llvm
+        if: steps.llvm-cache.outputs.cache-hit != 'true'
+        run: |
+          cd llvm-3.8.0.build
+          # if you're doing this by hand you might need `-- -j2` instead of `-j2`
+          cmake --build . --config Release -j2
+          cmake --build . --config Release -j2 --target llvm-as
+
+      - name: install llvm nix
+        if: steps.llvm-cache.outputs.cache-hit != 'true' && !contains(matrix.os, 'windows')
+        run: |
+          cd llvm-3.8.0.build
+          cmake --install .
+          cp bin/llvm-as $GITHUB_WORKSPACE/llvm-3.8.0.install/bin/
+
+      - name: install llvm windows
+        if: contains(matrix.os, 'windows') && steps.llvm-cache.outputs.cache-hit != 'true'
+        run: |
+          cd llvm-3.8.0.build
+          cmake --install . --prefix ../llvm-3.8.0.install
+          cp .\Release\bin\llvm-as.exe ../llvm-3.8.0.install/bin/
+
       - name: configure
         run: cd extempore && mkdir build && cd build && cmake -DASSETS=ON cmake ${{ matrix.cmake-generator }} ..
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,7 +54,8 @@ jobs:
           cmake -E tar xJf llvm-3.8.0.src.tar.xz
 
       - uses: actions/checkout@v2
-        path: extempore
+        with:
+          path: extempore
 
       - name: patch llvm
         if: steps.llvm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -100,7 +100,7 @@ jobs:
       - name: configure, windows
         if: contains(matrix.os, 'windows')
         run: |
-          $env:EXT_LLVM_DIR = "$Env:$GITHUB_WORKSPACE/llvm-3.8.0.install"
+          $Env:EXT_LLVM_DIR = "$Env:GITHUB_WORKSPACE/llvm-3.8.0.install"
           cd extempore && mkdir build && cd build && cmake -DASSETS=ON ${{ matrix.cmake-generator }} ..
 
       - name: build, nix

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -87,10 +87,19 @@ jobs:
         with:
           path: extempore
 
-      - name: configure
-        env:
-          EXT_LLVM_DIR: "${{ env.GITHUB_WORKSPACE }}/llvm-3.8.0.install"
+      # I have no idea why env: seems to work fine above ^, but not here :(
+      - name: configure, nix
+        if: ${{ !contains(matrix.os, 'windows') }}
         run: |
+          cd extempore
+          mkdir build
+          cd build
+          env EXT_LLVM_DIR=$GITHUB_WORKSPACE/llvm-3.8.0.install cmake -DASSETS=ON ${{ matrix.cmake-generator }} ..
+
+      - name: configure, windows
+        if: contains(matrix.os, 'windows')
+        run: |
+          $Env:EXT_LLVM_DIR="$Env:GITHUB_WORKSPACE/llvm-3.8.0.install"
           cd extempore
           mkdir build
           cd build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,6 +35,26 @@ jobs:
           sudo apt update
           sudo apt-get install libasound2-dev xorg-dev libglu1-mesa-dev
 
+      - name: cache llvm
+        id: llvm-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./llvm-3.8.0.install
+          key: ${{ matrix.os }}-llvm.3.8.0-0 # bump this number if you want to trigger an LLVM build
+
+      - name: download and unpack llvm, nixes
+        if: steps.llvm-cache.outputs.cache-hit != 'true' && !contains(matrix.os, 'windows')
+        run: |
+          wget "https://releases.llvm.org/3.8.0/llvm-3.8.0.src.tar.xz"
+          cmake -E tar xJf llvm-3.8.0.src.tar.xz
+
+      - name: download and unpack llvm, windows
+        if: contains(matrix.os, 'windows') && steps.llvm-cache.outputs.cache-hit != 'true'
+        run: |
+          Invoke-webrequest "https://releases.llvm.org/3.8.0/llvm-3.8.0.src.tar.xz" -outfile llvm-3.8.0.src.tar.xz
+          cmake -E tar xJf llvm-3.8.0.src.tar.xz
+
       - name: configure
         run: mkdir build && cd build && cmake -DASSETS=ON cmake ${{ matrix.cmake-generator }} ..
 


### PR DESCRIPTION
It takes a long time to build LLVM. I've been building LLVM 11.0 as a separate step in my [llvm-refactor branch](https://github.com/nic-donaldson/extempore/blob/llvm-refactor/.github/workflows/build-and-test.yml) to get faster feedback from CI. I've mostly copied that process over for LLVM 3.8.

It makes the workflow file longer and harder to read, but I think the time save is worth it.

Let me know what you think! I've left the commit history untouched, but I'm happy to rebase/squash it to something more reasonable if you like.