### PR TITLE
fix CLOCK_REALTIME undefined error in linux compil

### DIFF
--- a/include/UNIV.h
+++ b/include/UNIV.h
@@ -160,6 +160,7 @@ extern "C" inline double getRealTime()
 }
 
 #elif __linux__
+#include <time.h>
 
 extern "C" inline double getRealTime()
 {


### PR DESCRIPTION
Fix a compiling error on linux

[ 20%] Building CXX object CMakeFiles/extempore.dir/src/Extempore.cpp.o
Dans le fichier inclus depuis /home/calisdecris/dev/extempore/src/Extempore.cpp:38:
/home/calisdecris/dev/extempore/include/UNIV.h: Dans la fonction « double getRealTime() »:
/home/calisdecris/dev/extempore/include/UNIV.h:167:19: erreur: « CLOCK_REALTIME » n'a pas été déclaré dans cette portée
  167 |     clock_gettime(CLOCK_REALTIME, &t);
      |                   ^~~~~~~~~~~~~~
/home/calisdecris/dev/extempore/include/UNIV.h:167:19: note: la macro « CLOCK_REALTIME » n'a pas encore été définie
Dans le fichier inclus depuis /usr/include/time.h:33,
                 depuis /usr/lib64/gcc/x86_64-solus-linux/12/include-fixed/pthread.h:32,
                 depuis /home/calisdecris/dev/extempore/include/EXTThread.h:43,
                 depuis /home/calisdecris/dev/extempore/include/SchemePrivate.h:61,
                 depuis /home/calisdecris/dev/extempore/include/SchemeProcess.h:40,
                 depuis /home/calisdecris/dev/extempore/src/Extempore.cpp:39:
/usr/include/bits/time.h:46: note: elle a été définie ici plus tard
   46 | # define CLOCK_REALTIME                 0
      | 
/home/calisdecris/dev/extempore/include/UNIV.h:167:5: erreur: « clock_gettime » n'a pas été déclaré dans cette portée
  167 |     clock_gettime(CLOCK_REALTIME, &t);
      |     ^~~~~~~~~~~~~
make[2]: *** [CMakeFiles/extempore.dir/build.make:76 : CMakeFiles/extempore.dir/src/Extempore.cpp.o] Erreur 1
make[1]: *** [CMakeFiles/Makefile2:271 : CMakeFiles/extempore.dir/all] Erreur 2
make: *** [Makefile:166 : all] Erreur 2