### PR TITLE
Fix typos in pc_ivl.xtm

### DIFF
--- a/libs/core/pc_ivl.xtm
+++ b/libs/core/pc_ivl.xtm
@@ -278,7 +278,7 @@
 
 
 ;; quantize pc
-;; Always slelects a higher value before a lower value where distance is equal.
+;; Always selects a higher value before a lower value where distance is equal.
 ;;
 ;; arg 1: pitch to quantize to pc
 ;; arg 2: pc to quantize pitch against
@@ -296,12 +296,12 @@
                      #f)))))
 
 ;; quantize pc
-;; Always slelects a lower value before a higher value where distance is equal.
+;; Always selects a lower value before a higher value where distance is equal.
 ;;
 ;; arg 1: pitch to quantize to pc
 ;; arg 2: pc to quantize pitch against
 ;;
-;; returns quntized pitch or #f if non available
+;; returns quantized pitch or #f if non available
 ;;
 (define pc:quantize-low
    (lambda (pitch-in pc)
@@ -687,7 +687,7 @@
              chord))))
 
 
-;; genereate a melody from a list of steps in a (pc) pitch class
+;; generate a melody from a list of steps in a (pc) pitch class
 (define pc:melody-by-step
    (lambda (starting-pitch steps pc . args)
       (if (null? steps)
@@ -700,7 +700,7 @@
                                  (cons (pc:relative starting-pitch (car steps) pc) (car args)))))))
 
 
-;; generate a meldoy from a list of intervals
+;; generate a melody from a list of intervals
 (define ivl:melody-by-ivl
    (lambda (starting-pitch ivls . args)
       (if (null? ivls)


### PR DESCRIPTION
While walking through the codebase I noticed some typos