### PR TITLE
C++ modernisation followups: FFI thread safety, RAII, jthread migration

### DIFF
--- a/backlog/completed/task-040 - Audit-LLVM_SCHEME_FF_MAP-and-FFI-table-thread-safety.md
+++ b/backlog/completed/task-040 - Audit-LLVM_SCHEME_FF_MAP-and-FFI-table-thread-safety.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-040
 title: Audit LLVM_SCHEME_FF_MAP and FFI table thread safety
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-19 02:05'
+updated_date: '2026-04-19 03:40'
 labels:
   - cpp
   - concurrency
@@ -20,4 +21,14 @@ Audit real access patterns and guard with std::shared_mutex or atomic
 counters where appropriate.
 
 Follow-up from #419.
+
+## Resolution
+
+- s_ffiTable / s_ffiCount: s_ffiCount is now std::atomic<int> with
+  fetch_add; s_ffiTable entries are std::atomic<foreign_func> with
+  release/acquire pairing between mk_foreign_func and ffi_trampoline.
+  No mutex on the hot path.
+- LLVM_SCHEME_FF_MAP: guarded with std::shared_mutex (shared_lock on
+  get, unique_lock on set). The getter now uses find() instead of
+  operator[] to avoid inserting an empty string for unknown ff.
 <!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-039 - RAII-conversion-audio-scheme-thread-ownership.md
+++ b/backlog/tasks/task-039 - RAII-conversion-audio-scheme-thread-ownership.md
@@ -4,6 +4,7 @@ title: 'RAII conversion: audio/scheme thread ownership'
 status: To Do
 assignee: []
 created_date: '2026-04-19 02:04'
+updated_date: '2026-04-19 03:40'
 labels:
   - cpp
   - refactor
@@ -17,10 +18,21 @@ priority: medium
 Convert remaining owning raw pointers to unique_ptr/value types. Follow-up
 from the 2026-04-19 C++ modernisation PR (#419):
 
-- AudioDevice::m_threads[MAX_RT_AUDIO_THREADS] → std::array<std::unique_ptr<EXTThread>, N>
-- SchemeProcess/SchemeREPL singletons → Meyers singletons
-- SchemeTask::m_ptr → std::variant<std::string*, SchemeObj*, pointer>
-- Per-thread thread_local PRNGs (EXTLLVM.cpp:392,397) → values not pointers
+Done in the #419 follow-up PR:
+
+- [x] AudioDevice::m_threads[MAX_RT_AUDIO_THREADS] → std::array<std::unique_ptr<EXTThread>, N>
+- [x] Per-thread thread_local PRNGs (EXTLLVM.cpp:392,397) → values not pointers
+
+Still to do:
+
+- [ ] SchemeProcess/SchemeREPL registries → Meyers singletons.
+      SchemeREPL::sm_repls is a static std::unordered_map<std::string, SchemeREPL*>
+      and SchemeProcess::sm_current is a thread_local SchemeProcess*.
+      Straightforward refactor but needs audit of lifetime expectations.
+- [ ] SchemeTask::m_ptr → std::variant<std::string*, SchemeObj*, pointer>.
+      Hot path in task dispatch, touched by every case branch in
+      SchemeProcess::taskImpl; migration touches many call sites and the
+      variant alternative per case differs.
 
 See docs/superpowers/plans/2026-04-19-cpp-modernisation.md §5 for context.
 <!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-044 - Migrate-EXTThread-to-std-jthread-where-RT-not-needed.md
+++ b/backlog/tasks/task-044 - Migrate-EXTThread-to-std-jthread-where-RT-not-needed.md
@@ -4,6 +4,7 @@ title: 'Migrate EXTThread to std::jthread where RT not needed'
 status: To Do
 assignee: []
 created_date: '2026-04-19 02:05'
+updated_date: '2026-04-19 03:40'
 labels:
   - cpp
   - refactor
@@ -24,4 +25,30 @@ directly. Audit and migrate where safe; keep a small rt_thread helper
 just for the audio callback threads.
 
 Follow-up from #419.
+
+## Progress
+
+Migrated in the #419 follow-up PR:
+
+- [x] src/Extempore.cpp — the primary delayed-connect thread and the
+      linenoise REPL thread, both fire-and-forget, now use
+      std::thread + detach.
+
+Must keep EXTThread (verified):
+
+- AudioDevice::m_threads[] — RT priority (SCHED_RR / THREAD_TIME_CONSTRAINT_POLICY)
+- SchemeProcess::m_threadTask — uses setSubsume() + setPriority()
+- SchemeProcess::m_threadServer — uses setPriority()
+- EXTLLVM::thread_fork / thread_join / thread_kill — xtlang FFI exposes
+  EXTThread* as opaque void*; migration breaks ABI.
+
+Remaining candidates (safe by inspection, not yet touched):
+
+- [ ] TaskScheduler::m_queueThread — singleton, never joined, no RT.
+      Could be std::jthread. Defer until there's a clear destruction
+      story for the singleton.
+- [ ] OSC::threadOSC — needs reworking of the `getThread().start()` /
+      `getThread().start(fn, arg)` API shape to match std::thread's
+      construct-with-callable idiom; touches OSC::startSender /
+      startReceiver call sites.
 <!-- SECTION:DESCRIPTION:END -->

--- a/include/AudioDevice.h
+++ b/include/AudioDevice.h
@@ -50,6 +50,8 @@
 
 #include <cstdint>
 
+#include <array>
+#include <memory>
 #include <vector>
 #include "UNIV.h"
 #include "EXTThread.h"
@@ -86,7 +88,7 @@ private:
     SAMPLE* inbuf;
     float* outbuf_f;
     float* inbuf_f;
-    EXTThread* m_threads[MAX_RT_AUDIO_THREADS];
+    std::array<std::unique_ptr<EXTThread>, MAX_RT_AUDIO_THREADS> m_threads;
     unsigned   m_numThreads;
     bool       m_zeroLatency;
     bool       m_toggle;
@@ -151,7 +153,6 @@ public:
     void initMTAudio(int NumThreads, bool ZeroLatency);
     void initMTAudioBuf(int,bool);
 
-    EXTThread** getMTThreads() { return m_threads; }
     int getNumThreads() { return m_numThreads; }
     dsp_f_ptr getDSPWrapper() { return dsp_wrapper; }
     dsp_f_ptr_array getDSPWrapperArray() { return dsp_wrapper_array; }

--- a/src/AudioDevice.cpp
+++ b/src/AudioDevice.cpp
@@ -487,6 +487,15 @@ AudioDevice::AudioDevice(): m_started(false), buffer(0), m_dsp_closure(nullptr),
 
 AudioDevice::~AudioDevice()
 {
+    // The RT audio threads run `while(true)` loops and are intentionally
+    // leaked at process exit.  std::thread would call std::terminate if
+    // destroyed while joinable, so detach each EXTThread before the
+    // unique_ptr in m_threads destroys the underlying std::thread.
+    for (auto& t : m_threads) {
+        if (t && t->isRunning()) {
+            t->detach();
+        }
+    }
     if (stream && !UNIV::AUDIO_NONE) {
         PaError err;
         err = Pa_StopStream(stream);
@@ -679,7 +688,8 @@ void AudioDevice::initMTAudio(int Num, bool ZeroLatency)
     outbuf = (SAMPLE*) malloc(UNIV::CHANNELS*UNIV::NUM_FRAMES*sizeof(SAMPLE)*m_numThreads*2);
     memset(outbuf, 0, UNIV::CHANNELS*UNIV::NUM_FRAMES*sizeof(SAMPLE)*m_numThreads*2);
     for (unsigned i = 0; i < m_numThreads; ++i) {
-        m_threads[i] = new EXTThread(audioCallbackMT, reinterpret_cast<void*>(uintptr_t(i)),
+        m_threads[i] = std::make_unique<EXTThread>(audioCallbackMT,
+                reinterpret_cast<void*>(uintptr_t(i)),
                 std::string("MT_AUD_") + char('A' + i));
         m_threads[i]->start();
     }
@@ -697,8 +707,9 @@ void AudioDevice::initMTAudioBuf(int Num, bool ZeroLatency)
     inbuf_f = (float*) malloc(UNIV::IN_CHANNELS*UNIV::NUM_FRAMES*4);
     outbuf_f = (float*) malloc(UNIV::CHANNELS*UNIV::NUM_FRAMES*4*m_numThreads);
     for (unsigned i = 0; i < m_numThreads; ++i) {
-        m_threads[i] = new EXTThread(audioCallbackMTBuf, reinterpret_cast<void*>(uintptr_t(i)),
-            std::string("MT_AUDB_") + char('A' + i));
+        m_threads[i] = std::make_unique<EXTThread>(audioCallbackMTBuf,
+                reinterpret_cast<void*>(uintptr_t(i)),
+                std::string("MT_AUDB_") + char('A' + i));
         m_threads[i]->start();
     }
 }

--- a/src/EXTLLVM.cpp
+++ b/src/EXTLLVM.cpp
@@ -81,6 +81,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstdarg>
+#include <ctime>
 #include <mutex>
 #include <shared_mutex>
 
@@ -397,15 +398,13 @@ EXPORT void llvm_print_f64(double num)
 // these shouldn't ever be large, so it should be ok to cast to signed
 // int for returning into xtlang (which prefers signed ints). I hope
 // this doesn't come back to bite me one day.
-static thread_local std::minstd_rand* sRandGen;
+static thread_local std::minstd_rand sRandGen{
+    static_cast<std::minstd_rand::result_type>(std::time(nullptr))};
 
 EXPORT double imp_randd()
 {
-    if (unlikely(!sRandGen)) {
-        sRandGen = new std::minstd_rand(time(nullptr));
-    }
     // The existing implementation *COULD* (p = 1 / RAND_MAX) return 1!, but I don't think that was intended
-    return std::uniform_real_distribution<double>()(*sRandGen);
+    return std::uniform_real_distribution<double>()(sRandGen);
 }
 
 EXPORT float imp_randf()

--- a/src/EXTLLVM.cpp
+++ b/src/EXTLLVM.cpp
@@ -82,6 +82,7 @@
 #include <cstdlib>
 #include <cstdarg>
 #include <mutex>
+#include <shared_mutex>
 
 #include <EXTLLVM.h>
 #include <ext/NetUtil.h>
@@ -134,9 +135,12 @@
 
 #include "SchemeProcess.h"
 
-// llvm_scheme foreign function -> string name
-// also is not thread safe!
+// llvm_scheme foreign function -> string name.  std::map keeps iterators /
+// stored strings stable across inserts, so a reader that copied out .c_str()
+// under a shared lock can safely use it after releasing the lock (we never
+// erase entries).
 std::map<foreign_func, std::string> LLVM_SCHEME_FF_MAP;
+static std::shared_mutex LLVM_SCHEME_FF_MAP_MUTEX;
 
 EXPORT void* malloc16(size_t Size)
 {
@@ -218,13 +222,18 @@ EXPORT double fp80_to_double_portable(const unsigned char* bytes)
 
 const char* llvm_scheme_ff_get_name(foreign_func ff)
 {
-    return LLVM_SCHEME_FF_MAP[ff].c_str();
+    std::shared_lock<std::shared_mutex> lock(LLVM_SCHEME_FF_MAP_MUTEX);
+    auto it = LLVM_SCHEME_FF_MAP.find(ff);
+    if (it == LLVM_SCHEME_FF_MAP.end()) {
+        return "";
+    }
+    return it->second.c_str();
 }
 
-void llvm_scheme_ff_set_name(foreign_func ff,const char* name)
+void llvm_scheme_ff_set_name(foreign_func ff, const char* name)
 {
+    std::unique_lock<std::shared_mutex> lock(LLVM_SCHEME_FF_MAP_MUTEX);
     LLVM_SCHEME_FF_MAP[ff] = std::string(name);
-    return;
 }
 
 // LLVM RUNTIME ERROR

--- a/src/Extempore.cpp
+++ b/src/Extempore.cpp
@@ -453,16 +453,17 @@ EXPORT int extempore_init(int argc, char** argv)
 #else
         primary = new extemp::SchemeProcess(extemp::UNIV::SHARE_DIR, primary_name, primary_port, 0, initexpr);
 
-        // need to connect to primary from alternate thread (can be short lived simply puts repl on heap)
-        extemp::EXTThread* replthread = new extemp::EXTThread(extempore_primary_repl_delayed_connect,primary);
+        // Fire-and-forget: both helpers run for the life of the process and
+        // don't need the RT-scheduling / subsume features of EXTThread, so
+        // std::thread + detach is sufficient.  Detaching mirrors the
+        // previous behaviour of leaking the EXTThread*.
         pass_primary_port = primary_port;
-        replthread->start();
+        std::thread([primary] { extempore_primary_repl_delayed_connect(primary); }).detach();
 
 #ifndef _WIN32
         if (repl_mode) {
             auto* repl_args = new linenoise_repl_args{host, primary_port};
-            auto* repl_thread = new extemp::EXTThread(linenoise_repl, repl_args, "linenoise_repl");
-            repl_thread->start();
+            std::thread([repl_args] { linenoise_repl(repl_args); }).detach();
         }
 #endif
 

--- a/src/SchemeS7.cpp
+++ b/src/SchemeS7.cpp
@@ -1,5 +1,6 @@
 #include "SchemeS7Private.h"
 #include <array>
+#include <atomic>
 #include <iostream>
 #include <mutex>
 #include <unordered_map>
@@ -23,15 +24,18 @@ void scheme_register_wrapper(s7_scheme* raw_sc, scheme* wrapper)
 }
 
 static constexpr int MAX_FFI_FUNCS = 4096;
-static foreign_func s_ffiTable[MAX_FFI_FUNCS];
-static int s_ffiCount = 0;
+// Registration can race across scheme instances; reads happen from every
+// scheme call.  Atomics give us a happens-before between the store in
+// mk_foreign_func and the load here with no mutex on the hot path.
+static std::atomic<foreign_func> s_ffiTable[MAX_FFI_FUNCS];
+static std::atomic<int> s_ffiCount{0};
 
 template<int N>
 static s7_pointer ffi_trampoline(s7_scheme* raw_sc, s7_pointer args)
 {
     scheme* wrapper = scheme_wrapper_from_s7(raw_sc);
     try {
-        return s_ffiTable[N](wrapper, args);
+        return s_ffiTable[N].load(std::memory_order_acquire)(wrapper, args);
     } catch (const ScmRuntimeError& e) {
         return s7_error(raw_sc, s7_make_symbol(raw_sc, "wrong-type-arg"),
                         s7_list(raw_sc, 1, s7_make_string(raw_sc, e.msg)));
@@ -532,13 +536,13 @@ pointer mk_character(scheme* sc, int c)
 
 pointer mk_foreign_func(scheme* sc, foreign_func f)
 {
-    int slot = s_ffiCount++;
+    int slot = s_ffiCount.fetch_add(1, std::memory_order_relaxed);
     if (slot >= MAX_FFI_FUNCS) {
         printf("Too many FFI functions registered (slot %d, max %d)\n", slot, MAX_FFI_FUNCS);
         fflush(stdout);
         return sc->F;
     }
-    s_ffiTable[slot] = f;
+    s_ffiTable[slot].store(f, std::memory_order_release);
     return s7_make_function(sc->sc, "#<foreign>", s_trampolineTable[slot], 0, 0, true, nullptr);
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #419 covering three backlog items: TASK-040, partial TASK-039 and partial TASK-044. Based on `cpp-modernisation` so it only shows the follow-up work.

### TASK-040 — FFI thread safety (done)

- `s_ffiCount` is now `std::atomic<int>` with `fetch_add` for slot assignment.
- `s_ffiTable` entries are `std::atomic<foreign_func>` with release/acquire pairing between `mk_foreign_func` and `ffi_trampoline<N>` — no mutex on the hot path.
- `LLVM_SCHEME_FF_MAP` is guarded with `std::shared_mutex` (shared on get, unique on set). The getter now uses `find()` rather than `operator[]`, which also fixes a latent bug of inserting empty strings for unknown keys.

### TASK-039 — RAII (partial)

- `AudioDevice::m_threads[MAX_RT_AUDIO_THREADS]` raw `EXTThread*` array → `std::array<std::unique_ptr<EXTThread>, N>`. Destructor detaches each running thread so `unique_ptr` destruction doesn't trip `std::terminate` (these threads intentionally run `while(true)` for the life of the process). The unused `getMTThreads()` accessor is removed.
- `thread_local std::minstd_rand*` → value-typed `thread_local std::minstd_rand`, seeded lazily with `time(nullptr)` on first access. No more heap allocation, no more per-call null check.

Remaining (kept on the backlog): SchemeProcess/REPL registries → Meyers singletons, and `SchemeTask::m_ptr` → `std::variant`.

### TASK-044 — EXTThread → std::thread/jthread (partial)

- The primary delayed-connect thread and the linenoise REPL thread in `Extempore.cpp` were leaked `new EXTThread(...)`. Now `std::thread(...).detach()`, matching the fire-and-forget intent.

Kept on EXTThread for documented reasons (RT priority, `setSubsume`, or xtlang FFI ABI): AudioDevice m_threads, SchemeProcess::m_threadTask/m_threadServer, and the xtlang `thread_fork` API.

## Test plan

- [x] `cmake --build build --target extempore` — clean
- [x] `ctest --label-regex \"libs-core|cpp-unit|compiler-unit\"` — 19/19 pass
- [x] `ctest --label-regex \"libs-external\"` — 1/1 pass
- [x] `cmake --build build --target aot_external_audio` — builds
- [x] `./extempore --batch \"(begin (println 'hello) (quit 0))\"` — runs
- [ ] CI: Linux x64 / macOS arm64 / Windows x64 matrix